### PR TITLE
Login, Reset and Password Template Updates

### DIFF
--- a/ProcessMaker/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/ProcessMaker/Http/Controllers/Auth/ForgotPasswordController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace ProcessMaker\Http\Controllers\Auth;
+
+use ProcessMaker\Http\Controllers\Controller;
+use Illuminate\Foundation\Auth\SendsPasswordResetEmails;
+
+class ForgotPasswordController extends Controller
+{
+    /*
+    |--------------------------------------------------------------------------
+    | Password Reset Controller
+    |--------------------------------------------------------------------------
+    |
+    | This controller is responsible for handling password reset emails and
+    | includes a trait which assists in sending these notifications from
+    | your application to your users. Feel free to explore this trait.
+    |
+    */
+
+    use SendsPasswordResetEmails;
+
+    /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->middleware('guest');
+    }
+}

--- a/ProcessMaker/Http/Controllers/Auth/ResetPasswordController.php
+++ b/ProcessMaker/Http/Controllers/Auth/ResetPasswordController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ProcessMaker\Http\Controllers\Auth;
+
+use ProcessMaker\Http\Controllers\Controller;
+use Illuminate\Foundation\Auth\ResetsPasswords;
+
+class ResetPasswordController extends Controller
+{
+    /*
+    |--------------------------------------------------------------------------
+    | Password Reset Controller
+    |--------------------------------------------------------------------------
+    |
+    | This controller is responsible for handling password reset requests
+    | and uses a simple trait to include this behavior. You're free to
+    | explore this trait and override any methods you wish to tweak.
+    |
+    */
+
+    use ResetsPasswords;
+
+    /**
+     * Where to redirect users after resetting their password.
+     *
+     * @var string
+     */
+    protected $redirectTo = '/home';
+
+    /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->middleware('guest');
+    }
+}

--- a/resources/assets/sass/layouts-app.scss
+++ b/resources/assets/sass/layouts-app.scss
@@ -691,3 +691,17 @@ table.vuetable {
     font-size: 23px;
   }
 }
+
+.formContainer {
+    margin-top: 98px
+}
+
+.formContainer form {
+  background-color: white;
+  padding: 20px 30px;
+  text-align: left
+}
+
+.form-check {
+  margin-bottom: 10px
+}

--- a/resources/assets/sass/layouts-app.scss
+++ b/resources/assets/sass/layouts-app.scss
@@ -696,10 +696,10 @@ table.vuetable {
     margin-top: 98px
 }
 
-.formContainer form {
+.formContainer .form {
   background-color: white;
   padding: 20px 30px;
-  text-align: left
+  
 }
 
 .form-check {

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -47,21 +47,13 @@
 </div>
 @endsection
 @section('css')
-<style lang="scss" scoped>
+  <style media="screen">
   .formContainer {
-    width: 520px;
-    margin-top: 98px
+      width:504px;
   }
-
   .formContainer form {
-    background-color: white;
-    padding: 20px 30px;
-    margin-top: 85px;
-    text-align: left
+    margin-top:85px;
   }
+  </style>
 
-  .form-check {
-    margin-bottom: 10px
-  }
-</style>
 @endsection

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,87 +1,67 @@
 @extends('layouts.minimal')
-
 @section('content')
-<div class="container mt-5">
-  <div class="row">
-
-    <div class="col">
-    </div>
-
-    <div class="col-6">
-      <div align="center">
-        <img class="p-5" src="/img/md-blue-logo.png">
-      </div>
-
-      <form method="POST" action="{{ route('login') }}" class="bg-light p-5">
-        {{ csrf_field() }}
-
+<div align="center">
+  <div class="formContainer">
+    <img src="/img/md-blue-logo.png">
+    <form method="POST" action="{{ route('login') }}">
+      {{ csrf_field() }}
       <div class="form-group">
         <label for="username">{{ __('Username') }}</label>
         <div>
           <input id="username" type="text" class="form-control{{ $errors->has('username') ? ' is-invalid' : '' }}" name="username" value="{{ old('username') }}" required>
-
           @if ($errors->has('username'))
-
-          <span class="invalid-feedback">
-            <strong>{{ $errors->first('username') }}</strong>
-          </span>
+            <span class="invalid-feedback">
+              <strong>{{ $errors->first('username') }}</strong>
+            </span>
           @endif
         </div>
       </div>
-
       <div class="form-group">
         <label for="password">{{ __('Password') }}</label>
-          <div class="">
+        <div class="">
           <input id="password" type="password" class="form-control{{ $errors->has('password') ? ' is-invalid' : '' }}" name="password" required>
-
           @if ($errors->has('password'))
-
-          <span class="invalid-feedback">
-            <strong>{{ $errors->first('password') }}</strong>
-          </span>
+            <span class="invalid-feedback">
+              <strong>{{ $errors->first('password') }}</strong>
+            </span>
           @endif
         </div>
       </div>
-
+      <div class="form-check">
+        <label class="form-check-label">
+      <input class="form-check-input" type="checkbox" name="remember" {{ old('remember') ? 'checked' : '' }}>
+      {{ __('Remember me') }}</label>
+      </div>
       <div class="form-group">
-        <label for="password">{{ __('Language') }}</label>
-        <select class="form-control">
-          <option>English</option>
-          <option>Spanish</option>
-          <option>Portugese</option>
-          <option>Japanese</option>
-        </select>
+        <button type="submit" class="btn btn-success btn-block text-uppercase">{{ __('Login') }}</button>
       </div>
-
-      <div class="form-check mb-2">
-          <label class="form-check-label">
-        <input class="form-check-input" type="checkbox" name="remember" {{ old('remember') ? 'checked' : '' }}>
-        {{ __('Remember me') }}</label>
+      <div class="form-group">
+        <small>
+          <a href="{{ route('password.request') }}">
+            {{ __('Forgot Password?') }}
+          </a>
+        </small>
       </div>
-
-      <button type="submit" class="btn btn-secondary btn-block mb-2 text-light text-uppercase">
-        {{ __('Login') }}
-      </button>
-
-        <a class="btn-link text-primary pl-0" href="{{ route('password.request') }}">
-          {{ __('Forgot Password?') }}
-        </a>
-      </form>
-    </div>
-
-    <div class="col">
-    </div>
-
+    </form>
   </div>
+</div>
 @endsection
 @section('css')
-  <style lang="scss" scoped>
-    button{
-      margin-top: 10px;
-    }
-    a {
-      font-size: 14px;
-      margin-top: 8px;
-    }
-  </style>
+<style lang="scss" scoped>
+  .formContainer {
+    width: 520px;
+    margin-top: 98px
+  }
+
+  .formContainer form {
+    background-color: white;
+    padding: 20px 30px;
+    margin-top: 85px;
+    text-align: left
+  }
+
+  .form-check {
+    margin-bottom: 10px
+  }
+</style>
 @endsection

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -3,7 +3,7 @@
 <div align="center">
   <div class="formContainer">
     <img src="/img/md-blue-logo.png">
-    <form method="POST" action="{{ route('login') }}">
+    <form method="POST" class="form" action="{{ route('login') }}">
       {{ csrf_field() }}
       <div class="form-group">
         <label for="username">{{ __('Username') }}</label>
@@ -51,8 +51,9 @@
   .formContainer {
       width:504px;
   }
-  .formContainer form {
+  .formContainer .form {
     margin-top:85px;
+    text-align: left
   }
   </style>
 

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -6,7 +6,7 @@
     <img src="/img/md-blue-logo.png">
     <h3>{{__('Forgot Your Password?')}}</h3>
     <small>{{__("Enter your email address and we'll send you a reset link.")}}</small>
-<form method="POST" class="form" action="{{ route('password.email') }}">
+    <form method="POST" class="form" action="{{ route('password.email') }}">
       @if (session('status'))
       <div class="alert alert-success">
         {{ session('status') }}
@@ -29,7 +29,6 @@
         <small>
             <a href="/login">{{__("Back to Login")}}</a>
         </small>
-
       </div>
     </form>
   </div>

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -1,47 +1,59 @@
-@extends('layouts.app')
+@extends('layouts.minimal')
 
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">{{ __('Reset Password') }}</div>
+<div align="center">
+  <div class="formContainer">
+    <img src="/img/md-blue-logo.png">
+    <h3>{{__('Forgot Your Password?')}}</h3>
+    <small>{{__("Enter your email address and we'll send you a reset link.")}}</small>
+<form method="POST" action="{{ route('password.email') }}">
+      @if (session('status'))
+      <div class="alert alert-success">
+        {{ session('status') }}
+      </div>
+      @endif
+      @csrf
+      <div class="form-group">
+        <label for="email">{{ __('Email Address') }}</label>
+        <input id="email" type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email" value="{{ old('email') }}" required>
+        @if ($errors->has('email'))
+        <span class="invalid-feedback">
+          <strong>{{ $errors->first('email') }}</strong>
+        </span>
+        @endif
+      </div>
+      <div class="form-group">
+        <button type="submit" class="btn btn-success btn-block">{{ __('Request Reset Link') }}</button>
+      </div>
+      <div class="form-group">
+        <small>
+            <a href="/login">{{__("Back to Login")}}</a>
+        </small>
 
-                <div class="card-body">
-                    @if (session('status'))
-                        <div class="alert alert-success">
-                            {{ session('status') }}
-                        </div>
-                    @endif
-
-                    <form method="POST" action="{{ route('password.email') }}">
-                        @csrf
-
-                        <div class="form-group row">
-                            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('Email Address') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email" value="{{ old('email') }}" required>
-
-                                @if ($errors->has('email'))
-                                    <span class="invalid-feedback">
-                                        <strong>{{ $errors->first('email') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group row mb-0">
-                            <div class="col-md-6 offset-md-4">
-                                <button type="submit" class="btn btn-primary">
-                                    {{ __('Send Password Reset Link') }}
-                                </button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-            </div>
-        </div>
-    </div>
+      </div>
+    </form>
+  </div>
 </div>
+@endsection
+@section('css')
+  <style media="screen">
+
+  .formContainer {
+    width:400px;
+  }
+
+  .formContainer form {
+    margin-top:50px;
+  }
+
+  .formContainer  h3 {
+      margin-top: 52px;
+      font-size: 18px;
+      font-weight: 600;
+    }
+
+  .formContainer button {
+    margin-top: 6px;
+  }
+  </style>
 @endsection

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -18,7 +18,7 @@
                         @csrf
 
                         <div class="form-group row">
-                            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('E-Mail Address') }}</label>
+                            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('Email Address') }}</label>
 
                             <div class="col-md-6">
                                 <input id="email" type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email" value="{{ old('email') }}" required>

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -6,7 +6,7 @@
     <img src="/img/md-blue-logo.png">
     <h3>{{__('Forgot Your Password?')}}</h3>
     <small>{{__("Enter your email address and we'll send you a reset link.")}}</small>
-<form method="POST" action="{{ route('password.email') }}">
+<form method="POST" class="form" action="{{ route('password.email') }}">
       @if (session('status'))
       <div class="alert alert-success">
         {{ session('status') }}
@@ -42,8 +42,9 @@
     width:400px;
   }
 
-  .formContainer form {
+  .formContainer .form {
     margin-top:50px;
+    text-align: left;
   }
 
   .formContainer  h3 {

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -5,7 +5,7 @@
   <div class="formContainer">
     <img src="/img/md-blue-logo.png">
     <h3>{{__('Reset Your Password')}}</h3>
-    <form role="form" method="POST" action="{{ url('/password/reset') }}">
+    <form role="form" class="form" method="POST" action="{{ url('/password/reset') }}">
       {{ csrf_field() }} {{-- Needs to be enable when we hook up Controllers <input type="hidden" name="token" value="{{ $token }}"> --}}
       <div class="form-group{{ $errors->has('password') ? ' has-error' : '' }}">
         <label for="password">{{__('New Password')}}</label>
@@ -29,8 +29,9 @@
     width: 400px;
   }
 
-  .formContainer form {
+  .formContainer .form {
     margin-top: 50px;
+    text-align: left;
   }
 
   .formContainer h3 {

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -4,7 +4,7 @@
 <div align="center">
   <div class="formContainer">
     <img src="/img/md-blue-logo.png">
-    <h3>{{__('Forgot Your Password?')}}</h3>
+    <h3>{{__('Reset Your Password')}}</h3>
     <form role="form" method="POST" action="{{ url('/password/reset') }}">
       {{ csrf_field() }} {{-- Needs to be enable when we hook up Controllers <input type="hidden" name="token" value="{{ $token }}"> --}}
       <div class="form-group{{ $errors->has('password') ? ' has-error' : '' }}">

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -1,70 +1,72 @@
-@extends('layouts.app')
+@extends('layouts.minimal')
 
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">{{ __('Reset Password') }}</div>
-
-                <div class="card-body">
-                    <form method="POST" action="{{ route('password.request') }}">
-                        @csrf
-
-                        <input type="hidden" name="token" value="{{ $token }}">
-
-                        <div class="form-group row">
-                            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('E-Mail Address') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email" value="{{ $email or old('email') }}" required autofocus>
-
-                                @if ($errors->has('email'))
-                                    <span class="invalid-feedback">
-                                        <strong>{{ $errors->first('email') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
-                            <label for="password" class="col-md-4 col-form-label text-md-right">{{ __('Password') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password" type="password" class="form-control{{ $errors->has('password') ? ' is-invalid' : '' }}" name="password" required>
-
-                                @if ($errors->has('password'))
-                                    <span class="invalid-feedback">
-                                        <strong>{{ $errors->first('password') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
-                            <label for="password-confirm" class="col-md-4 col-form-label text-md-right">{{ __('Confirm Password') }}</label>
-                            <div class="col-md-6">
-                                <input id="password-confirm" type="password" class="form-control{{ $errors->has('password_confirmation') ? ' is-invalid' : '' }}" name="password_confirmation" required>
-
-                                @if ($errors->has('password_confirmation'))
-                                    <span class="invalid-feedback">
-                                        <strong>{{ $errors->first('password_confirmation') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group row mb-0">
-                            <div class="col-md-6 offset-md-4">
-                                <button type="submit" class="btn btn-primary">
-                                    {{ __('Reset Password') }}
-                                </button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-            </div>
-        </div>
+<div class="container mt-5">
+  <div class="row">
+    <div class="col">
     </div>
+    <div class="col-6">
+      <div align="center">
+        <img class="p-5" src="/img/md-blue-logo.png">
+      </div>
+      <div align="center">
+        <p class="header1">{{__('Forgot Your Password?')}}</p>
+        <p class="header2">{{__("Enter your email address and we'll send you a reset link.")}}</p>
+      </div>
+      <div align="center">
+        <form method="POST" action="{{ route('password.request') }}" class="bg-light p-4">
+          <div class="form-group">
+            <input type="hidden" name="token" value="{{ $token }}">
+            <label class="input-label">{{ __('Email Address') }}</label>
+            <div class="form-group">
+                <input id="email" type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email" value="{{ $email or old('email') }}" required autofocus>
+                @if ($errors->has('email'))
+                    <span class="invalid-feedback">
+                        <strong>{{ $errors->first('email') }}</strong>
+                    </span>
+                @endif
+            </div>
+            <button type="submit" class="btn btn-secondary btn-block mt-3 mb-3 text-light text-uppercase">
+              {{ __('REQUEST RESET LINK') }}
+            </button>
+            <a class=" text-primary input-link" href="{{ route('login') }}">
+              {{ __('Back to Login') }}
+            </a>
+          </div>
+        </form>
+      </div>
+    </div>
+    <div class="col">
+    </div>
+  </div>
 </div>
+@endsection
+
+@section('css')
+<style lang='scss' scoped>
+  img{
+    margin-top: 90px;
+  }
+  form{
+    width: 304px;
+  }
+  .header1{
+    font-size: 18px;
+    font-weight: 500;
+  }
+  .header2{
+    font-size: 14px;
+    margin-top: -12px;
+    font-weight: 400;
+    margin-bottom: 50px;
+  }
+  .input-label{
+    margin-left: -176px;
+  }
+  .input-link{
+    margin-left: -141px;
+    font-size: 14px;
+    margin-left: -176px;
+  }
+</style>
 @endsection

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -1,72 +1,46 @@
 @extends('layouts.minimal')
 
 @section('content')
-<div class="container mt-5">
-  <div class="row">
-    <div class="col">
-    </div>
-    <div class="col-6">
-      <div align="center">
-        <img class="p-5" src="/img/md-blue-logo.png">
+<div align="center">
+  <div class="formContainer">
+    <img src="/img/md-blue-logo.png">
+    <h3>{{__('Forgot Your Password?')}}</h3>
+    <form role="form" method="POST" action="{{ url('/password/reset') }}">
+      {{ csrf_field() }} {{-- Needs to be enable when we hook up Controllers <input type="hidden" name="token" value="{{ $token }}"> --}}
+      <div class="form-group{{ $errors->has('password') ? ' has-error' : '' }}">
+        <label for="password">{{__('New Password')}}</label>
+        <input id="password" type="password" class="form-control" name="password">
       </div>
-      <div align="center">
-        <p class="header1">{{__('Forgot Your Password?')}}</p>
-        <p class="header2">{{__("Enter your email address and we'll send you a reset link.")}}</p>
+      <div class="form-group{{ $errors->has('password_confirmation') ? ' has-error' : '' }}">
+        <label for="password-confirm">{{__('Confirm New Password')}}</label>
+        <input id="password-confirm" type="password" class="form-control" name="password_confirmation">
       </div>
-      <div align="center">
-        <form method="POST" action="{{ route('password.request') }}" class="bg-light p-4">
-          <div class="form-group">
-            <input type="hidden" name="token" value="{{ $token }}">
-            <label class="input-label">{{ __('Email Address') }}</label>
-            <div class="form-group">
-                <input id="email" type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email" value="{{ $email or old('email') }}" required autofocus>
-                @if ($errors->has('email'))
-                    <span class="invalid-feedback">
-                        <strong>{{ $errors->first('email') }}</strong>
-                    </span>
-                @endif
-            </div>
-            <button type="submit" class="btn btn-secondary btn-block mt-3 mb-3 text-light text-uppercase">
-              {{ __('REQUEST RESET LINK') }}
-            </button>
-            <a class=" text-primary input-link" href="{{ route('login') }}">
-              {{ __('Back to Login') }}
-            </a>
-          </div>
-        </form>
+      <div class="form-group">
+        <button type="submit" class="btn btn-success btn-block">{{__('Reset Password')}}</button>
       </div>
-    </div>
-    <div class="col">
-    </div>
+    </form>
   </div>
 </div>
-@endsection
 
+@endsection
 @section('css')
-<style lang='scss' scoped>
-  img{
-    margin-top: 90px;
+<style media="screen">
+  .formContainer {
+    width: 400px;
   }
-  form{
-    width: 304px;
+
+  .formContainer form {
+    margin-top: 50px;
   }
-  .header1{
+
+  .formContainer h3 {
+    margin-top: 52px;
     font-size: 18px;
-    font-weight: 500;
+    font-weight: 600;
   }
-  .header2{
-    font-size: 14px;
-    margin-top: -12px;
-    font-weight: 400;
-    margin-bottom: 50px;
-  }
-  .input-label{
-    margin-left: -176px;
-  }
-  .input-link{
-    margin-left: -141px;
-    font-size: 14px;
-    margin-left: -176px;
+
+  .formContainer button {
+    margin-top: 6px;
   }
 </style>
 @endsection

--- a/resources/views/auth/passwords/success.blade.php
+++ b/resources/views/auth/passwords/success.blade.php
@@ -1,0 +1,36 @@
+@extends('layouts.minimal')
+
+@section('content')
+<div align="center">
+  <div class="formContainer">
+    <img src="/img/md-blue-logo.png">
+    <div class="form" align="center">
+      <div class="form-group">
+        <small>
+          <strong>{{__('Success!')}}</strong> {{__('Your password has been updated.')}}
+        </small>
+      </div>
+      <div class="form-group">
+        <a href="/login" class="btn btn-success">{{__('Return to Login')}}</a>
+      </div>
+    </div>
+  </div>
+</div>
+
+@endsection
+@section('css')
+<style media="screen">
+  .formContainer {
+    width: 400px;
+  }
+
+  .formContainer .form {
+    margin-top: 114px;
+    text-align: center
+  }
+
+  .formContainer a {
+    margin-top: 14px;
+  }
+</style>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,9 @@ Auth::routes();
 $this->get('login', 'Auth\LoginController@showLoginForm')->name('login');
 $this->post('login', 'Auth\LoginController@login');
 $this->get('logout', 'Auth\LoginController@logout')->name('logout');
+$this->get('password/newpass', function(){
+  return view('auth.passwords.reset',['title' => __('Reset Your Password')]);
+})->name('password-reset');
 
 // Password Reset Routes...
 // $this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm')->name('password.request');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+Auth::routes();
 
 // Authentication Routes...
 $this->get('login', 'Auth\LoginController@showLoginForm')->name('login');
@@ -7,10 +8,14 @@ $this->post('login', 'Auth\LoginController@login');
 $this->get('logout', 'Auth\LoginController@logout')->name('logout');
 
 // Password Reset Routes...
-$this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm')->name('password.request');
-$this->post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail')->name('password.email');
-$this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name('password.reset');
-$this->post('password/reset', 'Auth\ResetPasswordController@reset');
+// $this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm')->name('password.request');
+// $this->post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail')->name('password.email');
+// $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name('password.reset');
+// $this->post('password/reset', 'Auth\ResetPasswordController@reset');
+
+// $this->get('password/reset/{token?}', 'Auth\PasswordController@showResetForm');
+// $this->post('password/email', 'Auth\PasswordController@sendResetLinkEmail');
+// $this->post('password/reset', 'Auth\PasswordController@reset');
 
 $this->middleware(['auth', 'apitoken'])->group(function() {
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,9 @@ $this->get('logout', 'Auth\LoginController@logout')->name('logout');
 $this->get('password/newpass', function(){
   return view('auth.passwords.reset',['title' => __('Reset Your Password')]);
 })->name('password-reset');
+$this->get('password/success', function(){
+  return view('auth.passwords.success',['title' => __('Success Your Password')]);
+})->name('password-success');
 
 // Password Reset Routes...
 // $this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm')->name('password.request');


### PR DESCRIPTION
There are 4 templates overhauled to match the design provided by @meadrat in issue #334 

There are routes for all three pages.

/login
/password/reset
/password/newpass
/password/success

Design Samples: 

Login: https://zpl.io/VQqAepW
Password Reset: https://zpl.io/a7ykoYW
New pass: https://zpl.io/aN0oe7n
Password Success: https://zpl.io/awY18p7

NOTE: I made the reset, success and new pass forms a little wider and consistent.