### PR TITLE
Redirect to process list when process not found

### DIFF
--- a/ProcessMaker/Http/Controllers/Designer/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Designer/ProcessController.php
@@ -22,18 +22,19 @@ class ProcessController extends Controller
     /**
      * Redirects to the view of the designer
      *
-     * @param Process $process
+     * @param string $process
      *
      * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
      */
-    public function show(Process $process = null)
+    public function show($process = null)
     {
-        if (!$process) {
-            request()->session()->flash('_alert', json_encode(['danger', __('The process was not found.')]));
-            return view('processes.index');
-        }
-        $title = $process->name;
+        $model = Process::where('uid', '=', $process)->first();
 
-        return view('designer.designer', compact(['process', 'title']));
+        if (!$model) {
+            request()->session()->flash('_alert', json_encode(['danger', __('The process was not found.')]));
+            return redirect('processes');
+        }
+        $title = $model->name;
+        return view('designer.designer', ['process' => $model, 'title' => $title]);
     }
 }

--- a/tests/Feature/Api/Designer/ProcessControllerTest.php
+++ b/tests/Feature/Api/Designer/ProcessControllerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature\Api\Cases;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Hash;
+use ProcessMaker\Model\DbSource;
+use ProcessMaker\Model\Process;
+use ProcessMaker\Model\ProcessVariable;
+use ProcessMaker\Model\Role;
+use ProcessMaker\Model\User;
+use Tests\Feature\Api\ApiTestCase;
+
+class ProcessControllerTest extends ApiTestCase
+{
+    use DatabaseTransactions;
+
+    /**
+     * Tests that the view with the selected process is displayed
+     */
+    public function testShowDiagram()
+    {
+        $process = factory(Process::class)->create();
+
+        $url = "/designer/" . $process->uid;
+
+        // Calling the designer with a correct process id should run correctly
+        $correctCall = $this->api('GET', $url);
+        $correctCall->assertStatus(200);
+        $this->assertFalse($correctCall->isRedirection());
+
+        // Calling the designer with a wrong process id should redirect
+        $url = "/designer/wrong-id";
+        $nonExistentProcessCall = $this->api('GET', $url);
+        $this->assertTrue($nonExistentProcessCall->isRedirection());
+
+        // Calling the designer without a process is should redirect
+        $url = "/designer";
+        $noProcessIdCall = $this->api('GET', $url);
+        $this->assertTrue($noProcessIdCall->isRedirection());
+    }
+
+    /**
+     * Overwrite of the setup method that authenticates and fills the default connection data
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        // we need an user and authenticate him
+        $user = factory(User::class)->create([
+            'password' => Hash::make('password'),
+            'role_id' => Role::where('code', Role::PROCESSMAKER_ADMIN)->first()->id
+        ]);
+
+        $this->auth($user->username, 'password');
+    }
+
+}


### PR DESCRIPTION
Changes done:
- When a the passed process id doesn't exist the controller redirects to the process list
- Added ProcessControllerTest.php  It tests that the ProcessController returns the view or executes a redirect depending of the existence of the process id 