### PR TITLE
Validation in the title when updating, blocks the edition

### DIFF
--- a/ProcessMaker/Model/Form.php
+++ b/ProcessMaker/Model/Form.php
@@ -66,7 +66,7 @@ class Form extends Model
         if ($field === 'title') {
             return Rule::unique('forms')->where(function ($query) {
                 $query->where('process_id', $this->process_id);
-            });
+            })->ignore($this->id);
         }
     }
 

--- a/ProcessMaker/Model/InputDocument.php
+++ b/ProcessMaker/Model/InputDocument.php
@@ -141,7 +141,7 @@ class InputDocument extends Model
         if ($field === 'title') {
             return Rule::unique('input_documents')->where(function ($query) {
                 $query->where('process_id', $this->process_id);
-            });
+            })->ignore($this->id);
         }
     }
 

--- a/ProcessMaker/Model/OutputDocument.php
+++ b/ProcessMaker/Model/OutputDocument.php
@@ -117,7 +117,7 @@ class OutputDocument extends Model
         if ($field === 'title') {
             return Rule::unique('output_documents')->where(function ($query) {
                 $query->where('process_id', $this->process_id);
-            });
+            })->ignore($this->id);
         }
     }
 

--- a/ProcessMaker/Model/Script.php
+++ b/ProcessMaker/Model/Script.php
@@ -83,7 +83,7 @@ class Script extends Model
         if ($field === 'title') {
             return Rule::unique('scripts')->where(function ($query) {
                 $query->where('process_id', $this->process_id);
-            });
+            })->ignore($this->id);
         }
     }
 

--- a/tests/Feature/Api/Designer/FormManagerTest.php
+++ b/tests/Feature/Api/Designer/FormManagerTest.php
@@ -327,6 +327,22 @@ class FormManagerTest extends ApiTestCase
     }
 
     /**
+     * Update Form with same title
+     */
+    public function testUpdateSameTitleForm()
+    {
+        //Post saved success
+        $faker = Faker::create();
+        $url = self::API_TEST_FORM . $this->process->uid . '/form/' . factory(Form::class)->create(['process_id' => $this->process->id])->uid;
+        $response = $this->api('PUT', $url, [
+            'description' => $faker->sentence(5),
+            'content' => '',
+        ]);
+        //Validate the answer is correct
+        $response->assertStatus(200);
+    }
+
+    /**
      * Delete Form in process
      */
     public function testDeleteForm()

--- a/tests/Feature/Api/Designer/InputDocumentManagerTest.php
+++ b/tests/Feature/Api/Designer/InputDocumentManagerTest.php
@@ -263,6 +263,28 @@ class InputDocumentManagerTest extends ApiTestCase
     }
 
     /**
+     * Update Input Document in process with same title
+     */
+    public function testUpdateInputDocumentSameTitle()
+    {
+        $faker = Faker::create();
+        //Post saved success
+        $url = self::API_TEST_INPUT_DOCUMENT . $this->process->uid . '/input-document/' . factory(InputDocument::class)->create([
+                'process_id' => $this->process->id
+            ])->uid;
+        $response = $this->api('PUT', $url, [
+            'description' => $faker->sentence(6),
+            'form_needed' => $faker->randomElement(array_keys(InputDocument::FORM_NEEDED_TYPE)),
+            'original' => $faker->randomElement(InputDocument::DOC_ORIGINAL_TYPE),
+            'published' => $faker->randomElement(InputDocument::DOC_PUBLISHED_TYPE),
+            'versioning' => $faker->randomElement([0, 1]),
+            'tags' => $faker->randomElement(InputDocument::DOC_TAGS_TYPE),
+        ]);
+        //Validate the answer is correct
+        $response->assertStatus(200);
+    }
+
+    /**
      * Delete Input Document in process
      */
     public function testDeleteInputDocument()

--- a/tests/Feature/Api/Designer/OutputDocumentManagerTest.php
+++ b/tests/Feature/Api/Designer/OutputDocumentManagerTest.php
@@ -364,6 +364,32 @@ class OutputDocumentManagerTest extends ApiTestCase
     }
 
     /**
+     * Update Document in process successfully with same title
+     */
+    public function testUpdateDocumentSameTitle()
+    {
+        $document = factory(Document::class)->create([
+            'process_id' => $this->process->id
+        ]);
+
+        $faker = Faker::create();
+
+        $url = self::API_OUTPUT_DOCUMENT_ROUTE . $this->process->uid . '/output-document/' . $document->uid;
+        $response = $this->api('PUT', $url, [
+            'description' => $faker->sentence(2),
+            'filename' => $faker->sentence(2),
+            'report_generator' => $faker->randomElement(Document::DOC_REPORT_GENERATOR_TYPE),
+            'generate' => $faker->randomElement(Document::DOC_GENERATE_TYPE),
+            'type' => $faker->randomElement(Document::DOC_TYPE),
+            'properties' => [
+                'pdf_security_permissions' => []
+            ]
+        ]);
+        //Validate the answer is correct
+        $response->assertStatus(200);
+    }
+
+    /**
      * Delete document successfully
      */
     public function testDeleteDocument()

--- a/tests/Feature/Api/Designer/ScriptManagerTest.php
+++ b/tests/Feature/Api/Designer/ScriptManagerTest.php
@@ -238,6 +238,26 @@ class ScriptManagerTest extends ApiTestCase
                 'code' => $faker->sentence($faker->randomDigitNotNull)
             ])->uid;
         $response = $this->api('PUT', $url, [
+            'description' => $faker->sentence(6),
+            'language' => 'php',
+            'code' => $faker->sentence(3),
+        ]);
+        //Validate the answer is correct
+        $response->assertStatus(204);
+    }
+
+    /**
+     * Update script in process with same title
+     */
+    public function testUpdateScriptSameTitle()
+    {
+        $faker = Faker::create();
+        //Post saved success
+        $url = self::API_TEST_SCRIPT . $this->process->uid . '/script/' . factory(Script::class)->create([
+                'process_id' => $this->process->id,
+                'code' => $faker->sentence($faker->randomDigitNotNull)
+            ])->uid;
+        $response = $this->api('PUT', $url, [
             'title' => $faker->sentence(2)
         ]);
         //Validate the answer is correct


### PR DESCRIPTION
Bugfix https://github.com/ProcessMaker/bpm/issues/572

- Add validation to ignore the current record ( Forms, input output documents, scrips).
- Add test for validate update ignoring current record.