### PR TITLE
#634 - Fix popover menus on Horizon

### DIFF
--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -1,6 +1,7 @@
 import 'bootstrap-vue/dist/bootstrap-vue.css'
 import BootstrapVue from 'bootstrap-vue'
 import Echo from 'laravel-echo'
+import VueRouter from 'vue-router'
 
 window._ = require('lodash');
 window.Popper = require('popper.js').default;
@@ -26,6 +27,7 @@ require('bootstrap');
 window.Vue = require('vue');
 
 window.Vue.use(BootstrapVue);
+window.Vue.use(VueRouter);
 
 window.ProcessMaker = {
     /**


### PR DESCRIPTION
Fixes #634

Horizon plugin requires the vue router to be included in the root app even though our app isn't using it.