### PR TITLE
Validation of script title

### DIFF
--- a/ProcessMaker/Model/Script.php
+++ b/ProcessMaker/Model/Script.php
@@ -67,7 +67,7 @@ class Script extends Model
     ];
 
     protected $validationMessages = [
-        'title.unique' => 'A Input Document with the same name already exists in this process.',
+        'title.unique' => 'A script with the same name already exists in this process.',
         'process_id.exists' => 'Process not found.'
     ];
 

--- a/tests/Feature/Api/Designer/ScriptManagerTest.php
+++ b/tests/Feature/Api/Designer/ScriptManagerTest.php
@@ -100,6 +100,30 @@ class ScriptManagerTest extends TestCase
     }
 
     /**
+     * Can not update a script title with an existing title
+     */
+    public function testNotUpdateScriptWithTitleExists()
+    {
+        $scriptOne = factory(Script::class)->create([
+            'title' => 'Script Title One',
+            'process_id' => $this->process->id
+        ]);
+        $scriptTwo = factory(Script::class)->create([
+            'title' => 'Script Title Two',
+            'process_id' => $this->process->id
+        ]);
+
+        //Post title duplicated
+        $faker = Faker::create();
+        $url = self::API_TEST_SCRIPT . $this->process->uid . '/script/' . $scriptTwo->uid;
+        $response = $this->actingAs($this->user, 'api')->json('PUT', $url, [
+            'title' => 'Script Title One',
+        ]);
+        $response->assertStatus(422);
+        $this->assertArrayHasKey('message', $response->json());
+    }
+
+    /**
      * Get a list of scripts in a project.
      */
     public function testListScripts()


### PR DESCRIPTION
Fix the script duplicated title message.

![image](https://user-images.githubusercontent.com/8028650/45221762-71d2d280-b280-11e8-8a0a-5d4d3ec401c4.png)

Added a test: Tests\Feature\Api\Designer\ScriptManagerTest::testNotUpdateScriptWithTitleExists
