### PR TITLE
Update circleci config for laravel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,6 +176,8 @@ jobs:
             # Run php artisan migrate:fresh --seed to have a clean installed database in RDS
             ssh -o "ProxyCommand ssh buildbot.processmaker.net -A -W %h:%p" qa-pm4builds "php ~/builds/$BUILD_NAME/artisan migrate:fresh --seed --force"
             echo "Deployed to https://${BUILD_NAME}.bpm4.qa.processmaker.net/"
+            # Run containerDeploy.sh script to spin up Redis docker container, laravel-echo-server, and horizon
+            ssh -o "ProxyCommand ssh buildbot.processmaker.net -A -W %h:%p" qa-pm4builds "sudo /bin/bash /root/cloudops/containerDeploy.sh $BUILD_NAME"
 
       #- run:
       #    name: "SauceLabs Browser Tests: Chrome"


### PR DESCRIPTION
update circleci config to run local containerDeploy.sh script. This creates assigns redis and laravel ports, spins up redis container, and laravel-echo-server and horizon processes via supervisord.