### PR TITLE
If user time zone is set to UTC, dates aren't formatted correctly 

### DIFF
--- a/resources/js/app-layout.js
+++ b/resources/js/app-layout.js
@@ -17,7 +17,8 @@ import moment from "moment"
 import moment_timezone from "moment-timezone";
 if (window.ProcessMaker && window.ProcessMaker.user) {
     moment.tz.setDefault(window.ProcessMaker.user.timezone);
-    moment.defaultFormat= window.ProcessMaker.user.datetime_format;
+    moment.defaultFormat = window.ProcessMaker.user.datetime_format;
+    moment.defaultFormatUtc = window.ProcessMaker.user.datetime_format;
 }
 Vue.prototype.moment = moment;
 //initializing global instance of a moment object

--- a/resources/js/data/datetime_formats.json
+++ b/resources/js/data/datetime_formats.json
@@ -6,7 +6,7 @@
   },
   {
     "format": "m/d/Y h:i A",
-    "momentFormat": "MM/DD/YYYY hh:mm A",
+    "momentFormat": "MM/DD/YYYY h:mm A",
     "title": "m/d/Y h:i A (12/31/2017 11:30 pm)"
   },
   {


### PR DESCRIPTION
Solves #911 
As is stated in http://momentjs.com/docs/#default-format, when the timezone is UTC, the default format string applied is defaultFormatUtc instead of defaultFormat. 

The bug was solved setting defaultFormatUtc with the same string used by defaultFormat. 