### PR TITLE
Use laravel-enum package and refactor ProcessVersion to use it.

### DIFF
--- a/ProcessMaker/Enums/ActiveType.php
+++ b/ProcessMaker/Enums/ActiveType.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ProcessMaker\Enums;
+
+use BenSampo\Enum\Contracts\LocalizedEnum;
+use BenSampo\Enum\Enum;
+
+final class ActiveType extends Enum implements LocalizedEnum
+{
+    const ACTIVE = "ACTIVE";
+    const INACTIVE = "INACTIVE";
+}

--- a/ProcessMaker/Models/ProcessVersion.php
+++ b/ProcessMaker/Models/ProcessVersion.php
@@ -2,7 +2,9 @@
 
 namespace ProcessMaker\Models;
 
+use BenSampo\Enum\Rules\EnumValue;
 use Illuminate\Database\Eloquent\Model;
+use ProcessMaker\Enums\ActiveType;
 
 /**
  * ProcessVersion is used to store the historical version of a process.
@@ -19,6 +21,15 @@ use Illuminate\Database\Eloquent\Model;
  */
 class ProcessVersion extends Model
 {
+    /**
+     * The model's attributes and default values
+     *
+     * @var array
+     */
+    protected $attributes = [
+        'status' => ActiveType::ACTIVE
+    ];
+
     /**
      * Attributes that are not mass assignable.
      *
@@ -61,7 +72,7 @@ class ProcessVersion extends Model
     {
         return [
             'name' => 'required',
-            'status' => 'in:ACTIVE,INACTIVE',
+            'status' => [new EnumValue(ActiveType::class)],
             'process_category_id' => 'exists:process_categories,id',
             'process_id' => 'exists:processes,id',
         ];

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
   "require": {
     "php": ">=7.2.0",
     "TYPO3/class-alias-loader": "^1.0",
+    "bensampo/laravel-enum": "^1.16",
     "darkaonline/l5-swagger": "5.7.*",
     "doctrine/dbal": "^2.5",
     "fideloper/proxy": "^4.0",

--- a/database/factories/ProcessVersionFactory.php
+++ b/database/factories/ProcessVersionFactory.php
@@ -1,6 +1,7 @@
 <?php
 
 use Faker\Generator as Faker;
+use ProcessMaker\Enums\ActiveType;
 use ProcessMaker\Models\ProcessVersion;
 use ProcessMaker\Models\Process;
 use ProcessMaker\Models\ProcessCategory;
@@ -13,12 +14,20 @@ $factory->define(ProcessVersion::class, function (Faker $faker) {
     return [
         'bpmn' => file_get_contents($emptyProcess),
         'name' => $faker->sentence(3),
-        'status' => $faker->randomElement(['ACTIVE', 'INACTIVE']),
+        'status' => ActiveType::getRandomValue(),
         'process_category_id' => function () {
             return factory(ProcessCategory::class)->create()->getKey();
         },
         'process_id' => function () {
-                return factory(Process::class)->create()->getKey();
+            return factory(Process::class)->create()->getKey();
         }
     ];
 });
+
+foreach (ActiveType::getKeys() as $key) {
+    $factory->state(ProcessVersion::class, $key, function ($faker) use ($key) {
+        return [
+            'status' => ActiveType::getValue($key),
+        ];
+    });
+}

--- a/database/migrations/2018_09_07_175156_create_process_versions_table.php
+++ b/database/migrations/2018_09_07_175156_create_process_versions_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use ProcessMaker\Enums\ActiveType;
 
 class CreateProcessVersionsTable extends Migration
 {
@@ -20,8 +21,7 @@ class CreateProcessVersionsTable extends Migration
             $table->string('name');
             $table->unsignedInteger('process_category_id');
             $table->unsignedInteger('process_id');
-            $table->enum('status', ['ACTIVE', 'INACTIVE'])
-                    ->default('ACTIVE');
+            $table->enum('status', ActiveType::getValues())->default(ActiveType::ACTIVE);
             $table->timestamps();
 
             // Indexes

--- a/resources/lang/en/enums.php
+++ b/resources/lang/en/enums.php
@@ -1,0 +1,14 @@
+<?php
+
+
+use ProcessMaker\Enums\ActiveType;
+
+return [
+
+    ActiveType::class => [
+        ActiveType::ACTIVE => 'Active',
+        ActiveType::INACTIVE => 'Inactive',
+    ],
+
+];
+


### PR DESCRIPTION
To clarify my idea in #913, this is an intial PR to clarify how can laravel/enum help write better status code.

- [x] Introduce simple ActiveType enum class
- [x] Enhance process versions migration
- [x] Localize ready statuses using resource/lang/[LANG]/enum.php file
- [x] Set default value using model `$attributes` array
- [x] Enhance the status validation rule using `EnumValue` custom rule
- [x] Enhance Factory random status generation
- [x] Easily generated factory states using `ActiveType::getKeys`

All of these changes are backward compatible and need no changes to the tests. Once the initial idea is accepted, I will update the PR to include the following:

Complete the same refactoring for other simple active status like:
- [ ] Refactor ScreenCategory status
- [ ] Refactor ProcessCategory status
- [ ] Refactor Process status
- [ ] Refactor Group status
- [ ] Refactor User status

Introduce new type for each more complex statuses like:
- [ ] Process Request Token statuses
- [ ] Process Request statuses

It will not only cover the `status` but I will also use it for
- [ ] Group member type
- [ ] ....