### PR TITLE
feature/930 Fix CircleCI config and fix a failing test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,9 @@ jobs:
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
       - image: circleci/mysql:5.7
+        environment:
+          - MYSQL_ROOT_PASSWORD: P4ssW0rd1!
+          - MYSQL_DATABASE: circle_test
 
       # Add support for Microsoft SQL Server Testing
       - image: microsoft/mssql-server-linux:2017-GA
@@ -128,6 +131,8 @@ jobs:
           command: "./vendor/bin/phpunit -d memory_limit=-1 --coverage-html coverage"
           environment:
             DB_DATABASE: "circle_test"
+            DB_PASSWORD: "P4ssW0rd1!"
+            DB_USERNAME: "root"
             RUN_MSSQL_TESTS: "true"
             MSSQL_HOST: "127.0.0.1"
             MSSQL_PORT: "1433"

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -34,7 +34,7 @@ class AuthTest extends TestCase
         // Build a user with a specified password
         $user = factory(User::class)->create([
             'username' =>'newuser',
-            'password' => Hash::make('password')
+            'password' => 'password'
         ]);
         // Make sure we have a failed attempt with a bad password
         $this->assertFalse(Auth::attempt([


### PR DESCRIPTION
Fixes #930 

Somehow the test db setup on CircleCi was failing but it wasn't reporting that it failed (non zero result?). This fixes the CI config and the test that should have been failing on CI but doesn't address why CI was passing but should have been failing when setting up the test db.