### PR TITLE
summary screen dropdown in process edit should only show display screens

### DIFF
--- a/ProcessMaker/Http/Controllers/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/ProcessController.php
@@ -27,8 +27,8 @@ class ProcessController extends Controller
 
         $screens = Screen::orderBy('title')
                     ->get()
-                    ->pluck('title', 'id')
                     ->where('type', 'DISPLAY')
+                    ->pluck('title', 'id')
                     ->toArray();
         return view('processes.edit', compact('process', 'categories', 'screens'));
     }

--- a/ProcessMaker/Http/Controllers/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/ProcessController.php
@@ -28,8 +28,8 @@ class ProcessController extends Controller
         $screens = Screen::orderBy('title')
                     ->get()
                     ->pluck('title', 'id')
+                    ->where('type', 'display')
                     ->toArray();
-
         return view('processes.edit', compact('process', 'categories', 'screens'));
     }
 

--- a/ProcessMaker/Http/Controllers/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/ProcessController.php
@@ -28,7 +28,7 @@ class ProcessController extends Controller
         $screens = Screen::orderBy('title')
                     ->get()
                     ->pluck('title', 'id')
-                    ->where('type', 'display')
+                    ->where('type', 'DISPLAY')
                     ->toArray();
         return view('processes.edit', compact('process', 'categories', 'screens'));
     }


### PR DESCRIPTION
in the Process controller the screens variable is now being filtered to only show 'display' screen types in the edit process screen.

![screen shot 2018-11-27 at 4 25 34 pm](https://user-images.githubusercontent.com/29641725/49120377-2ae1f100-f261-11e8-8d5c-19393ce39b61.png)
