### PR TITLE
Sco 2345

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,7 @@ jobs:
             echo "BROADCASTER_KEY=21a795019957dde6bcd96142e05d4b10" >> .env
             echo "REDIS_PORT=%%REDISPORT%%" >> .env
             echo "BPM_SCRIPTS_HOME=/home/circleci/tmp" >> .env
+            echo "HOME=/home/circleci" >> .env
             
             # Generate unique app key
             php artisan key:generate --force

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ jobs:
             echo "SAUCELABS_BROWSER_TESTING=true" >> .env
             echo "SAUCELABS_USERNAME=${SAUCELABS_USERNAME}" >> .env
             echo "SAUCELABS_ACCESS_KEY=${SAUCELABS_ACCESS_KEY}" >> .env
-            # Put in configuration file for Braoodcaster
+            # Put in configuration file for Broadcaster
             echo "BROADCAST_DRIVER=redis" >> .env
             echo "BROADCASTER_HOST=%%BROADCASTER_HOST%%" >> .env
             echo "BROADCASTER_KEY=21a795019957dde6bcd96142e05d4b10" >> .env


### PR DESCRIPTION
Add HOME env variable to .env on circleci deployment. This allows certain docker containers to be spun up using /home/circleci directory rather than /root for config.json lookup