### PR TITLE
Files tab show only if files exist

### DIFF
--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -32,10 +32,12 @@
                                 <a class="nav-link" id="completed-tab" data-toggle="tab" href="#completed" role="tab"
                                    aria-controls="completed" aria-selected="false">{{__('Completed')}}</a>
                             </li>
+                            @if(count($files) > 0 )                           
                             <li class="nav-item">
                                 <a class="nav-link" id="files-tab" data-toggle="tab" href="#files" role="tab"
                                    aria-controls="files" aria-selected="false">{{__('Attached Files')}}</a>
                             </li>
+                            @endif
                         </template>
                     </ul>
                     <div class="tab-content" id="requestTabContent">


### PR DESCRIPTION
fixes #1004 

to test: start a process that does not have a file upload. In the summary screen there will no longer be a tab for "attached files" unless the request has files. 