### PR TITLE
User Groups

### DIFF
--- a/ProcessMaker/Http/Controllers/Admin/GroupController.php
+++ b/ProcessMaker/Http/Controllers/Admin/GroupController.php
@@ -5,31 +5,33 @@ namespace ProcessMaker\Http\Controllers\Admin;
 use Illuminate\Http\Request;
 use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Models\Group;
+use ProcessMaker\Models\User;
 
 class GroupController extends Controller
 {
-  /**
-   * Get the list of groups.
-   *
-   * @return \Illuminate\View\View|\Illuminate\Contracts\View
-   */
-  public function index()
-  {
-    return view('admin.groups.index');
-  }
+    /**
+     * Get the list of groups.
+     *
+     * @return \Illuminate\View\View|\Illuminate\Contracts\View
+     */
+    public function index()
+    {
+        return view('admin.groups.index');
+    }
 
-  /**
-   * Get a specific group
-   *
-   * @return \Illuminate\View\View|\Illuminate\Contracts\View
-   */
-   public function edit(Group $group)
-   {
-     return view('admin.groups.edit', compact('group'));
-   }
+    /**
+     * Get a specific group
+     *
+     * @return \Illuminate\View\View|\Illuminate\Contracts\View
+     */
+    public function edit(Group $group)
+    {
+        $users = User::where('status', 'ACTIVE')->get();
+        return view('admin.groups.edit', compact('group', 'users'));
+    }
 
-   public function show(Group $group)
-   {
-       return view('admin.groups.show', compact('group'));
-   }
+    public function show(Group $group)
+    {
+        return view('admin.groups.show', compact('group'));
+    }
 }

--- a/ProcessMaker/Http/Controllers/Api/GroupController.php
+++ b/ProcessMaker/Http/Controllers/Api/GroupController.php
@@ -225,17 +225,17 @@ class GroupController extends Controller
     }
 
     /**
-     * Display a listing of the resource.
+     * Display the list of users in a group
      *
      * @param Request $request
      *
      * @return ApiCollection
      *
      * @OA\Get(
-     *     path="/groups",
-     *     summary="Returns all groups that the user has access to",
-     *     operationId="getGroups",
-     *     tags={"Groups"},
+     *     path="/group_users",
+     *     summary="Returns all users of a group",
+     *     operationId="getMembers",
+     *     tags={"Group_users"},
      *     @OA\Parameter(ref="#/components/parameters/filter"),
      *     @OA\Parameter(ref="#/components/parameters/order_by"),
      *     @OA\Parameter(ref="#/components/parameters/order_direction"),
@@ -244,13 +244,13 @@ class GroupController extends Controller
      *
      *     @OA\Response(
      *         response=200,
-     *         description="list of groups",
+     *         description="list of members of a group",
      *         @OA\JsonContent(
      *             type="object",
      *             @OA\Property(
      *                 property="data",
      *                 type="array",
-     *                 @OA\Items(ref="#/components/schemas/groups"),
+     *                 @OA\Items(ref="#/components/schemas/users"),
      *             ),
      *             @OA\Property(
      *                 property="meta",

--- a/ProcessMaker/Http/Controllers/Api/GroupMemberController.php
+++ b/ProcessMaker/Http/Controllers/Api/GroupMemberController.php
@@ -97,6 +97,15 @@ class GroupMemberController extends Controller
      */
     public function store(Request $request)
     {
+        $isMemberAssociated = GroupMember::where('group_id', $request->input('group_id'))
+            ->where ('member_type', $request->input('member_type'))
+            ->where ('member_id', $request->input('member_id'))
+            ->count();
+
+        if ($isMemberAssociated) {
+            return response([], 201);
+        }
+
         $request->validate(GroupMember::rules());
 
         $group = Group::findOrFail($request->input('group_id'));

--- a/resources/js/admin/groups/components/UsersInGroupListing.vue
+++ b/resources/js/admin/groups/components/UsersInGroupListing.vue
@@ -62,8 +62,8 @@
                     },
                     {
                         title: "Full Name",
-                        name: "fullname",
-                        sortField: "fullname"
+                        name: "firstname",
+                        sortField: "firstname"
                     },
                     {
                         title: "Status",

--- a/resources/js/admin/groups/components/UsersInGroupListing.vue
+++ b/resources/js/admin/groups/components/UsersInGroupListing.vue
@@ -16,14 +16,6 @@
                     <div class="popout">
                         <b-btn
                                 variant="action"
-                                @click="onEdit(props.rowData, props.rowIndex)"
-                                v-b-tooltip.hover
-                                title="Edit"
-                        >
-                            <i class="fas fa-edit"></i>
-                        </b-btn>
-                        <b-btn
-                                variant="action"
                                 @click="onDelete( props.rowData, props.rowIndex)"
                                 v-b-tooltip.hover
                                 title="Remove"

--- a/resources/js/admin/groups/components/UsersInGroupListing.vue
+++ b/resources/js/admin/groups/components/UsersInGroupListing.vue
@@ -80,24 +80,6 @@
                         callback: this.formatStatus
                     },
                     {
-                        title: "Modified",
-                        name: "updated_at",
-                        sortField: "updated_at",
-                        callback: "formatDate"
-                    },
-                    {
-                        title: "Created",
-                        name: "created_at",
-                        sortField: "created_at",
-                        callback: "formatDate"
-                    },
-                    {
-                        title: "Last login",
-                        name: "loggedin_at",
-                        sortField: "loggedin_at",
-                        callback: "formatDate"
-                    },
-                    {
                         name: "__slot:actions",
                         title: ""
                     }
@@ -131,8 +113,8 @@
                     "<b>Are you sure to delete the group </b>" + data.name + "?",
                     "",
                     function () {
-                        ProcessMaker.apiClient.delete("groups/" + data.id).then(response => {
-                            ProcessMaker.alert("Group successfully eliminated", "success");
+                        ProcessMaker.apiClient.delete("group_members/" + data.id).then(response => {
+                            ProcessMaker.alert("Member successfully eliminated", "success");
                             that.fetch();
                         });
                     }

--- a/resources/js/admin/groups/components/UsersInGroupListing.vue
+++ b/resources/js/admin/groups/components/UsersInGroupListing.vue
@@ -1,0 +1,192 @@
+<template>
+    <div class="data-table">
+        <vuetable
+                :dataManager="dataManager"
+                :sortOrder="sortOrder"
+                :css="css"
+                :api-mode="false"
+                @vuetable:pagination-data="onPaginationData"
+                :fields="fields"
+                :data="data"
+                data-path="data"
+                pagination-path="meta"
+        >
+            <template slot="actions" slot-scope="props">
+                <div class="actions">
+                    <div class="popout">
+                        <b-btn
+                                variant="action"
+                                @click="onEdit(props.rowData, props.rowIndex)"
+                                v-b-tooltip.hover
+                                title="Edit"
+                        >
+                            <i class="fas fa-edit"></i>
+                        </b-btn>
+                        <b-btn
+                                variant="action"
+                                @click="onDelete( props.rowData, props.rowIndex)"
+                                v-b-tooltip.hover
+                                title="Remove"
+                        >
+                            <i class="fas fa-trash-alt"></i>
+                        </b-btn>
+                    </div>
+                </div>
+            </template>
+        </vuetable>
+        <pagination
+                single="User"
+                plural="Users"
+                :perPageSelectEnabled="true"
+                @changePerPage="changePerPage"
+                @vuetable-pagination:change-page="onPageChange"
+                ref="pagination"
+        ></pagination>
+    </div>
+</template>
+
+<script>
+    import datatableMixin from "../../../components/common/mixins/datatable";
+
+    export default {
+        mixins: [datatableMixin],
+        props: ["groupId"],
+        data() {
+            return {
+                filter: "",
+                orderBy: "username",
+                // Our listing of users
+                sortOrder: [
+                    {
+                        field: "username",
+                        sortField: "username",
+                        direction: "asc"
+                    }
+                ],
+                fields: [
+                    {
+                        title: "Username",
+                        name: "username",
+                        sortField: "username"
+                    },
+                    {
+                        title: "Full Name",
+                        name: "fullname",
+                        sortField: "fullname"
+                    },
+                    {
+                        title: "Status",
+                        name: "status",
+                        sortField: "status",
+                        callback: this.formatStatus
+                    },
+                    {
+                        title: "Modified",
+                        name: "updated_at",
+                        sortField: "updated_at",
+                        callback: "formatDate"
+                    },
+                    {
+                        title: "Created",
+                        name: "created_at",
+                        sortField: "created_at",
+                        callback: "formatDate"
+                    },
+                    {
+                        title: "Last login",
+                        name: "loggedin_at",
+                        sortField: "loggedin_at",
+                        callback: "formatDate"
+                    },
+                    {
+                        name: "__slot:actions",
+                        title: ""
+                    }
+                ]
+            };
+        },
+        methods: {
+            formatStatus(status) {
+                status = status.toLowerCase();
+                let bubbleColor = {
+                    active: "text-success",
+                    inactive: "text-danger",
+                    draft: "text-warning",
+                    archived: "text-info"
+                };
+                return (
+                    '<i class="fas fa-circle ' +
+                    bubbleColor[status] +
+                    ' small"></i> ' +
+                    status.charAt(0).toUpperCase() +
+                    status.slice(1)
+                );
+            },
+            onEdit(data, index) {
+                window.location = "/admin/groups/" + data.id + "/edit";
+            },
+            onDelete(data, index) {
+                let that = this;
+                ProcessMaker.confirmModal(
+                    "Caution!",
+                    "<b>Are you sure to delete the group </b>" + data.name + "?",
+                    "",
+                    function () {
+                        ProcessMaker.apiClient.delete("groups/" + data.id).then(response => {
+                            ProcessMaker.alert("Group successfully eliminated", "success");
+                            that.fetch();
+                        });
+                    }
+                );
+            },
+            onAction(action, data, index) {
+                switch (action) {
+                    case "users-item":
+                        //todo
+                        break;
+                    case "permissions-item":
+                        //todo
+                        break;
+                }
+            },
+            fetch() {
+                this.loading = true;
+                // Load from our api client
+                ProcessMaker.apiClient
+                    .get(
+                        "group_users/" + this.groupId + "?page=" +
+                        this.page +
+                        "&per_page=" +
+                        this.perPage +
+                        "&filter=" + this.filter +
+                        "&group_id=" + this.groupId +
+                        "&order_by=" +
+                        this.orderBy +
+                        "&order_direction=" +
+                        this.orderDirection +
+                        this.filter +
+                        "&include=member"
+                    )
+                    .then(response => {
+                        this.data = this.transform(response.data);
+                        this.loading = false;
+                    });
+            }
+        }
+    };
+</script>
+
+<style lang="scss" scoped>
+    /deep/ th#_total_users {
+        width: 150px;
+        text-align: center;
+    }
+
+    /deep/ .vuetable-th-status {
+        min-width: 90px;
+    }
+
+    /deep/ .vuetable-th-members_count {
+        min-width: 90px;
+    }
+</style>

--- a/resources/js/admin/groups/components/UsersInGroupListing.vue
+++ b/resources/js/admin/groups/components/UsersInGroupListing.vue
@@ -50,10 +50,9 @@
 
     export default {
         mixins: [datatableMixin],
-        props: ["groupId"],
+        props: ["filter", "groupId"],
         data() {
             return {
-                filter: "",
                 orderBy: "username",
                 // Our listing of users
                 sortOrder: [
@@ -163,9 +162,7 @@
                         "&order_by=" +
                         this.orderBy +
                         "&order_direction=" +
-                        this.orderDirection +
-                        this.filter +
-                        "&include=member"
+                        this.orderDirection
                     )
                     .then(response => {
                         this.data = this.transform(response.data);

--- a/resources/js/admin/groups/edit.js
+++ b/resources/js/admin/groups/edit.js
@@ -1,5 +1,5 @@
 import Vue from "vue";
-import UsersListing from "../users/components/UsersListing.vue";
+import UsersInGroupListing from "./components/UsersInGroupListing.vue";
 
-Vue.component('users-listing', UsersListing);
+Vue.component('users-in-group', UsersInGroupListing);
 

--- a/resources/js/admin/groups/edit.js
+++ b/resources/js/admin/groups/edit.js
@@ -1,0 +1,5 @@
+import Vue from "vue";
+import UsersListing from "../users/components/UsersListing.vue";
+
+Vue.component('users-listing', UsersListing);
+

--- a/resources/views/admin/groups/edit.blade.php
+++ b/resources/views/admin/groups/edit.blade.php
@@ -16,9 +16,9 @@
                 <nav>
                     <div class="nav nav-tabs" id="nav-tab" role="tablist">
                         <a class="nav-item nav-link active" id="nav-home-tab" data-toggle="tab" href="#nav-home" role="tab"
-                           aria-controls="nav-home" aria-selected="true">Information</a>
+                           aria-controls="nav-home" aria-selected="true">Group Details</a>
                         <a class="nav-item nav-link" id="nav-profile-tab" data-toggle="tab" href="#nav-users" role="tab"
-                           aria-controls="nav-profile" aria-selected="false">Users</a>
+                           aria-controls="nav-profile" aria-selected="false">Group Members</a>
                     </div>
                 </nav>
 
@@ -51,7 +51,6 @@
                     </div>
 
                     <div class="tab-pane fade" id="nav-users" role="tabpanel" aria-labelledby="nav-profile-tab">
-                        <h1>{{__('Users in group')}}</h1>
                         <div class="row">
                             <div class="col">
                                 <div class="input-group">

--- a/resources/views/admin/groups/edit.blade.php
+++ b/resources/views/admin/groups/edit.blade.php
@@ -73,6 +73,53 @@
                     </div>
                 </div>
             </div>
+
+            <div class="modal" tabindex="-1" role="dialog" id="addUser">
+                <div class="modal-dialog" role="document">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title">{{__('Add Users')}}</h5>
+                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                <span aria-hidden="true">&times;</span>
+                            </button>
+                        </div>
+                        <div class="modal-body">
+                            <div class="form-user">
+                                {!!Form::label('users', __('Users'))!!}
+                                <multiselect v-model="selectedUsers" :options="availableUsers" :multiple="true"
+                                             track-by="name"
+                                             :custom-label="customLabel" :show-labels="false" label="name">
+
+                                    <template slot="tag" slot-scope="props">
+                                        <span class="multiselect__tag  d-flex align-items-center" style="width:max-content;">
+                                            <span class="option__desc mr-1">@{{ props.option.name }}
+                                                <span class="option__title">@{{ props.option.desc }}</span>
+                                            </span>
+                                            <i aria-hidden="true" tabindex="1" @click="props.remove(props.option)"
+                                               class="multiselect__tag-icon"></i>
+                                        </span>
+                                    </template>
+
+                                    <template slot="option" slot-scope="props">
+                                        <div class="option__desc d-flex align-items-center">
+                                            <span class="option__title mr-1">@{{ props.option.name }}</span>
+                                            <span class="option__small">@{{ props.option.desc }}</span>
+                                        </div>
+                                    </template>
+                                </multiselect>
+                            </div>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-outline-secondary"
+                                    data-dismiss="modal">{{__('Close')}}</button>
+                            <button type="button" class="btn btn-secondary" @click="onSubmit"
+                                    id="disabledForNow">{{__('Save')}}</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+
             <div class="col-4">
                 <div class="card card-body">
                     Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore
@@ -94,15 +141,25 @@
             data() {
                 return {
                     formData: @json($group),
-                    filter: "",
+                    filter: '',
                     errors: {
                         'name': null,
                         'description': null,
                         'status': null
-                    }
+                    },
+                    selectedUsers: [],
+                    availableUsers: [],
+                    {{--availableUsers: @json($users),--}}
                 }
             },
             methods: {
+                customLabel(options) {
+//                    return ` ${options.img} ${options.title} ${options.desc} `
+                    return 'nada';
+                },
+                onSubmit() {
+                    alert('todo: store users');
+                },
                 resetErrors() {
                     this.errors = Object.assign({}, {
                         name: null,

--- a/resources/views/admin/groups/edit.blade.php
+++ b/resources/views/admin/groups/edit.blade.php
@@ -69,7 +69,7 @@
                                     {{__('User')}}</button>
                             </div>
                         </div>
-                        <users-listing ref="listing" :filter="filter" v-on:reload="reload"></users-listing>
+                        <users-in-group ref="listing" :filter="filter" :group-id="formData.id"></users-in-group>
                     </div>
                 </div>
             </div>
@@ -89,12 +89,12 @@
 @section('js')
     <script src="{{mix('js/admin/groups/edit.js')}}"></script>
     <script>
-//        import datatableMixin from "js/components/common/mixins/datatable";
         new Vue({
             el: '#editGroup',
             data() {
                 return {
                     formData: @json($group),
+                    filter: "",
                     errors: {
                         'name': null,
                         'description': null,

--- a/resources/views/admin/groups/edit.blade.php
+++ b/resources/views/admin/groups/edit.blade.php
@@ -87,13 +87,13 @@
                             <div class="form-user">
                                 {!!Form::label('users', __('Users'))!!}
                                 <multiselect v-model="selectedUsers" :options="availableUsers" :multiple="true"
-                                             track-by="name"
-                                             :custom-label="customLabel" :show-labels="false" label="name">
+                                             track-by="fullname"
+                                             :custom-label="customLabel" :show-labels="false" label="fullname">
 
                                     <template slot="tag" slot-scope="props">
                                         <span class="multiselect__tag  d-flex align-items-center" style="width:max-content;">
-                                            <span class="option__desc mr-1">@{{ props.option.name }}
-                                                <span class="option__title">@{{ props.option.desc }}</span>
+                                            <span class="option__desc mr-1">
+                                                <span class="option__title">@{{ props.option.fullname }}</span>
                                             </span>
                                             <i aria-hidden="true" tabindex="1" @click="props.remove(props.option)"
                                                class="multiselect__tag-icon"></i>
@@ -102,8 +102,7 @@
 
                                     <template slot="option" slot-scope="props">
                                         <div class="option__desc d-flex align-items-center">
-                                            <span class="option__title mr-1">@{{ props.option.name }}</span>
-                                            <span class="option__small">@{{ props.option.desc }}</span>
+                                            <span class="option__title mr-1">@{{ props.option.fullname }}</span>
                                         </div>
                                     </template>
                                 </multiselect>
@@ -112,7 +111,7 @@
                         <div class="modal-footer">
                             <button type="button" class="btn btn-outline-secondary"
                                     data-dismiss="modal">{{__('Close')}}</button>
-                            <button type="button" class="btn btn-secondary" @click="onSubmit"
+                            <button type="button" class="btn btn-secondary" @click="onSave"
                                     id="disabledForNow">{{__('Save')}}</button>
                         </div>
                     </div>
@@ -140,6 +139,7 @@
             el: '#editGroup',
             data() {
                 return {
+                    showAddUserModal:false,
                     formData: @json($group),
                     filter: '',
                     errors: {
@@ -148,17 +148,25 @@
                         'status': null
                     },
                     selectedUsers: [],
-                    availableUsers: [],
-                    {{--availableUsers: @json($users),--}}
+                    availableUsers: @json($users)
                 }
             },
             methods: {
                 customLabel(options) {
-//                    return ` ${options.img} ${options.title} ${options.desc} `
-                    return 'nada';
+                    return `${options.fullname}`
                 },
-                onSubmit() {
-                    alert('todo: store users');
+                onSave() {
+                    let that = this;
+                    this.selectedUsers.forEach(function (user) {
+                        ProcessMaker.apiClient
+                            .post('group_members', {
+                                'group_id': that.formData.id,
+                                'member_type': 'ProcessMaker\\Models\\User',
+                                'member_id': user.id
+                            });
+                    })
+                    this.$refs['listing'].fetch();
+                    $('#addUser').modal('hide');
                 },
                 resetErrors() {
                     this.errors = Object.assign({}, {

--- a/resources/views/admin/groups/edit.blade.php
+++ b/resources/views/admin/groups/edit.blade.php
@@ -197,3 +197,49 @@
         });
     </script>
 @endsection
+
+@section('css')
+    <style>
+        .inline-input {
+            margin-right: 6px;
+        }
+        .inline-button {
+            background-color: rgb(109, 124, 136);
+            font-weight: 100;
+        }
+        .input-and-select {
+            width: 212px;
+        }
+        .multiselect__element span img {
+            border-radius: 50%;
+            height: 20px;
+        }
+        .multiselect__tags-wrap {
+            display: flex !important;
+        }
+        .multiselect__tags-wrap img {
+            height: 15px;
+            border-radius: 50%;
+        }
+        .multiselect__tag-icon:after {
+            color: white !important;
+        }
+        .multiselect__option--highlight {
+            background: #00bf9c !important;
+        }
+        .multiselect__option--selected.multiselect__option--highlight {
+            background: #00bf9c !important;
+        }
+        .multiselect__tags {
+            border: 1px solid #b6bfc6 !important;
+            border-radius: 0.125em !important;
+            height: calc(1.875rem + 2px) !important;
+        }
+        .multiselect__tag {
+            background: #788793 !important;
+        }
+        .multiselect__tag-icon:after {
+            color: white !important;
+        }
+    </style>
+@endsection

--- a/resources/views/admin/groups/edit.blade.php
+++ b/resources/views/admin/groups/edit.blade.php
@@ -13,30 +13,65 @@
         <h1>{{__('Edit Group')}}</h1>
         <div class="row">
             <div class="col-8">
-                <div class="card card-body">
-                    {!! Form::open() !!}
-                    <div class="form-group">
-                        {!! Form::label('name', 'Name') !!}
-                        {!! Form::text('name', null, ['id' => 'name','class'=> 'form-control', 'v-model' => 'formData.name', 'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.name}']) !!}
-                        <small class="form-text text-muted">Group name must be distinct</small>
-                        <div class="invalid-feedback" v-if="errors.name">@{{errors.name[0]}}</div>
+                <nav>
+                    <div class="nav nav-tabs" id="nav-tab" role="tablist">
+                        <a class="nav-item nav-link active" id="nav-home-tab" data-toggle="tab" href="#nav-home" role="tab"
+                           aria-controls="nav-home" aria-selected="true">Information</a>
+                        <a class="nav-item nav-link" id="nav-profile-tab" data-toggle="tab" href="#nav-users" role="tab"
+                           aria-controls="nav-profile" aria-selected="false">Users</a>
                     </div>
-                    <div class="form-group">
-                        {!! Form::label('description', 'Description') !!}
-                        {!! Form::textarea('description', null, ['id' => 'description', 'rows' => 4, 'class'=> 'form-control', 'v-model' => 'formData.description', 'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.description}']) !!}
-                        <div class="invalid-feedback" v-if="errors.description">@{{errors.description[0]}}</div>
+                </nav>
+
+
+                <div class="card card-body tab-content mt-3" id="nav-tabContent">
+                    <div class="tab-pane fade show active" id="nav-home" role="tabpanel" aria-labelledby="nav-home-tab">
+                        {!! Form::open() !!}
+                        <div class="form-group">
+                            {!! Form::label('name', 'Name') !!}
+                            {!! Form::text('name', null, ['id' => 'name','class'=> 'form-control', 'v-model' => 'formData.name', 'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.name}']) !!}
+                            <small class="form-text text-muted">Group name must be distinct</small>
+                            <div class="invalid-feedback" v-if="errors.name">@{{errors.name[0]}}</div>
+                        </div>
+                        <div class="form-group">
+                            {!! Form::label('description', 'Description') !!}
+                            {!! Form::textarea('description', null, ['id' => 'description', 'rows' => 4, 'class'=> 'form-control', 'v-model' => 'formData.description', 'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.description}']) !!}
+                            <div class="invalid-feedback" v-if="errors.description">@{{errors.description[0]}}</div>
+                        </div>
+                        <div class="form-group">
+                            {!! Form::label('status', 'Status') !!}
+                            {!! Form::select('status', ['ACTIVE' => 'Active', 'INACTIVE' => 'Inactive'], null, ['id' => 'status', 'class' => 'form-control', 'v-model' => 'formData.status', 'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.status}']) !!}
+                            <div class="invalid-feedback" v-if="errors.status">@{{errors.status[0]}}</div>
+                        </div>
+                        <br>
+                        <div class="text-right">
+                            {!! Form::button('Cancel', ['class'=>'btn btn-outline-success', '@click' => 'onClose']) !!}
+                            {!! Form::button('Update', ['class'=>'btn btn-success ml-2', '@click' => 'onUpdate']) !!}
+                        </div>
+                        {!! Form::close() !!}
                     </div>
-                    <div class="form-group">
-                        {!! Form::label('status', 'Status') !!}
-                        {!! Form::select('status', ['ACTIVE' => 'Active', 'INACTIVE' => 'Inactive'], null, ['id' => 'status', 'class' => 'form-control', 'v-model' => 'formData.status', 'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.status}']) !!}
-                        <div class="invalid-feedback" v-if="errors.status">@{{errors.status[0]}}</div>
+
+                    <div class="tab-pane fade" id="nav-users" role="tabpanel" aria-labelledby="nav-profile-tab">
+                        <h1>{{__('Users in group')}}</h1>
+                        <div class="row">
+                            <div class="col">
+                                <div class="input-group">
+                                    <div class="input-group-prepend">
+                                        <span class="input-group-text">
+                                            <i class="fas fa-search"></i>
+                                        </span>
+                                    </div>
+                                    <input v-model="filter" class="form-control" placeholder="{{__('Search')}}...">
+                                </div>
+
+                            </div>
+                            <div class="col-8" align="right">
+                                <button type="button" class="btn btn-action text-light" data-toggle="modal" data-target="#addUser">
+                                    <i class="fas fa-plus"></i>
+                                    {{__('User')}}</button>
+                            </div>
+                        </div>
+                        <users-listing ref="listing" :filter="filter" v-on:reload="reload"></users-listing>
                     </div>
-                    <br>
-                    <div class="text-right">
-                        {!! Form::button('Cancel', ['class'=>'btn btn-outline-success', '@click' => 'onClose']) !!}
-                        {!! Form::button('Update', ['class'=>'btn btn-success ml-2', '@click' => 'onUpdate']) !!}
-                    </div>
-                    {!! Form::close() !!}
                 </div>
             </div>
             <div class="col-4">
@@ -53,7 +88,9 @@
 @endsection
 
 @section('js')
+    <script src="{{mix('js/admin/groups/edit.js')}}"></script>
     <script>
+//        import datatableMixin from "js/components/common/mixins/datatable";
         new Vue({
             el: '#editGroup',
             data() {

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -86,30 +86,6 @@
                         'v-bind:class' => '{\'form-control\':true, \'is-invalid\':addError.password}'])!!}
 
                     </div>
-                    <div class="form-group">
-                        {!!Form::label('groups', __('Groups'))!!}
-                        <multiselect v-model="selectedGroups" :options="availableGroups" :multiple="true"
-                                     track-by="name"
-                                     :custom-label="customLabel" :show-labels="false" label="name">
-
-                            <template slot="tag" slot-scope="props">
-                            <span class="multiselect__tag  d-flex align-items-center" style="width:max-content;">
-                                <span class="option__desc mr-1">@{{ props.option.name }}
-                                    <span class="option__title">@{{ props.option.desc }}</span>
-                                </span>
-                                <i aria-hidden="true" tabindex="1" @click="props.remove(props.option)"
-                                   class="multiselect__tag-icon"></i>
-                            </span>
-                            </template>
-
-                            <template slot="option" slot-scope="props">
-                                <div class="option__desc d-flex align-items-center">
-                                    <span class="option__title mr-1">@{{ props.option.name }}</span>
-                                    <span class="option__small">@{{ props.option.desc }}</span>
-                                </div>
-                            </template>
-                        </multiselect>
-                    </div>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-outline-secondary"
@@ -138,13 +114,8 @@
                 confpassword: '',
                 addError: {},
                 submitted: false,
-                selectedGroups: [],
-                availableGroups: @json($groups),
             },
             methods: {
-                customLabel(options) {
-                    return ` ${options.img} ${options.title} ${options.desc} `
-                },
                 validatePassword() {
                     if (this.password !== this.confpassword) {
                         this.addError.password = ['Passwords must match']
@@ -164,48 +135,9 @@
                             status: this.status,
                             email: this.email,
                             password: this.password
-                        })
-                            .then(response => {
-                                ProcessMaker.alert('{{__('User successfully added ')}}', 'success');
-                                const promises = [];
-                                this.selectedGroups.forEach(group => {
-                                    promises.push(new Promise(
-                                        (resolve, reject) => {
-                                            ProcessMaker.apiClient.post("/group_members", {
-                                                member_type: "ProcessMaker\\Models\\User",
-                                                member_id: response.data.id,
-                                                group_id: group.id
-                                            })
-                                                .then(() => {
-                                                    resolve(true)
-                                                })
-                                                .catch(() => {
-                                                    ProcessMaker.alert('{{__('An error occurred while saving the Group')}}', 'danger');
-                                                    resolve(false)
-                                               })
-                                        })
-                                    )
-                                });
-
-                                Promise.all(promises)
-                                    .then(() => {
-                                        ProcessMaker.alert('{{__('Groups successfully added ')}}', 'success')
-                                    })
-                                    .catch(() => {
-                                        ProcessMaker.alert('{{__('Error when saving Group ')}}', 'danger')
-                                    })
-                                    .finally(() => {
-                                        window.location = "/admin/users/" + response.data.id + '/edit'
-                                    })
-                            })
-                            .catch(error => {
-                                if (error.response.status === 422) {
-                                    this.addError = error.response.data.errors
-                                }
-                            })
-                            .finally(() => {
-                                this.submitted = false
-                            })
+                        }).then(function (response) {
+                            window.location = "/admin/users/" + response.data.id + '/edit'
+                        });
                     }
                 }
             }

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ Route::group(
 
     Route::apiResource('users', 'UserController');
     Route::apiResource('groups', 'GroupController');
+    Route::get('group_users/{group}', 'GroupController@members');
     Route::apiResource('group_members', 'GroupMemberController')->only(['index', 'show', 'destroy', 'store']);
     Route::apiResource('environment_variables', 'EnvironmentVariablesController');
     Route::apiResource('screens', 'ScreenController');

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -34,6 +34,7 @@ mix.webpackConfig({
     .js('resources/js/processes/modeler/initialLoad.js', 'public/js/processes/modeler')
     .js('resources/js/admin/users/index.js', 'public/js/admin/users')
     .js('resources/js/admin/groups/index.js', 'public/js/admin/groups')
+    .js('resources/js/admin/groups/edit.js', 'public/js/admin/groups/edit.js')
     .js('resources/js/admin/queues/index.js', 'public/js/admin/queues')
 
     .js('resources/js/processes/index.js', 'public/js/processes')


### PR DESCRIPTION
Solves #949 
- Edit group now has a tab to add users
- The list of users in a group has filtering, sorting
- Users can be added selecting them with a multiselect widget
- All multiselects that were used for adding groups of a en user (when editing a user) were removed.


![editgroup2](https://user-images.githubusercontent.com/14875032/49957225-7f31d580-fedd-11e8-8daf-dce79e9d0df7.png)

![selectuser](https://user-images.githubusercontent.com/14875032/49957230-82c55c80-fedd-11e8-816f-1dfde24cd451.png)
