### PR TITLE
Hide Requests in Inactive Categories

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/NotificationController.php
+++ b/ProcessMaker/Http/Controllers/Api/NotificationController.php
@@ -14,6 +14,8 @@ use ProcessMaker\Models\User;
 
 class NotificationController extends Controller
 {
+    public $skipPermissionCheckFor = ['index', 'show'];
+
     /**
      * Display a listing of the resource.
      *

--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -20,7 +20,7 @@ use ProcessMaker\Models\User;
 
 class ProcessController extends Controller
 {
-    public $skipPermissionCheckFor = ['triggerStartEvent'];
+    public $skipPermissionCheckFor = ['triggerStartEvent', 'startProcesses'];
 
     /**
      * Get list Process
@@ -244,6 +244,65 @@ class ProcessController extends Controller
         }
 
         return new Resource($process->refresh());
+    }
+
+    /**
+     * Returns the list of processes that the user can start.
+     *
+     * @param Request $request
+     *
+     * @return ApiCollection
+     *
+     * * @OA\Get(
+     *     path="/start_processes",
+     *     summary="Returns the list of processes that the user can start",
+     *     operationId="startProcesses",
+     *     tags={"Process"},
+     *     @OA\Parameter(ref="#/components/parameters/order_by"),
+     *     @OA\Parameter(ref="#/components/parameters/order_direction"),
+     *     @OA\Parameter(ref="#/components/parameters/per_page"),
+     *     @OA\Parameter(ref="#/components/parameters/include"),
+     *
+     *     @OA\Response(
+     *         response=200,
+     *         description="list of processes that the user can start",
+     *         @OA\JsonContent(
+     *             type="object",
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="array",
+     *                 @OA\Items(ref="#/components/schemas/Process"),
+     *             ),
+     *             @OA\Property(
+     *                 property="meta",
+     *                 type="object",
+     *                 allOf={@OA\Schema(ref="#/components/schemas/metadata")},
+     *             ),
+     *         ),
+     *     ),
+     * )
+     */
+    public function startProcesses(Request $request)
+    {
+        $orderBy = $this->getRequestSortBy($request, 'name');
+        $perPage = $this->getPerPage($request);
+        $include = $this->getRequestInclude($request);
+
+        $processes = Process::with($include)
+            ->select('processes.*')
+            ->leftJoin('process_categories as category', 'processes.process_category_id', '=', 'category.id')
+            ->leftJoin('users as user', 'processes.user_id', '=', 'user.id')
+            ->where('processes.status', 'ACTIVE')
+            ->where('category.status', 'ACTIVE');
+
+        //Verify what processes the current user can initiate, user Administrator can start everything.
+        if (!Auth::user()->is_administrator) {
+            $processId = Auth::user()->startProcesses();
+            $processes->whereIn('processes.id', $processId);
+        }
+        $processes->orderBy(...$orderBy);
+
+        return new ApiCollection($processes->paginate($perPage));
     }
 
     private function savePermission($process, $assignableType, $assignableId, $permissionId)

--- a/ProcessMaker/Http/Controllers/NotificationController.php
+++ b/ProcessMaker/Http/Controllers/NotificationController.php
@@ -8,6 +8,8 @@ use ProcessMaker\Models\ProcessRequestToken;
 
 class NotificationController extends Controller
 {
+    public $skipPermissionCheckFor = ['index', 'show'];
+
     private static $dueLabels = [
         'open' => 'Due ',
         'completed' => 'Completed ',

--- a/resources/js/components/requests/modal.vue
+++ b/resources/js/components/requests/modal.vue
@@ -68,7 +68,7 @@ export default {
       // Maximum number of requests returned is 200 but should be enough
       // @todo Determine if we need to paginate or lazy scroll if someone has more than 200 requests
       window.ProcessMaker.apiClient
-        .get("processes?include=events,category")
+        .get("start_processes?include=events,category")
         .then(response => {
           let data = response.data;
           // Empty processes


### PR DESCRIPTION
Solves #1045 

- Just active processes and processes within active categories are listed when starting a process.
- It was added a new endpoint to list the processes that can be started by a user. That way we will avoid to use additional parameters in the process index endpoint, doing this will obfuscate and confuse the logic of the endpoint.
- An authorization problem with the notification listing for new users has been fixed. Now we are skipping the routing authorization for this endpoint, in the future a more complex authorization scheme should be used.