### PR TITLE
Process Category Remove Delete Option

### DIFF
--- a/resources/js/processes/categories/components/CategoriesListing.vue
+++ b/resources/js/processes/categories/components/CategoriesListing.vue
@@ -28,6 +28,7 @@
                 @click="onAction('remove-item', props.rowData, props.rowIndex)"
                 v-b-tooltip.hover
                 title="Remove"
+                v-if="props.rowData.processes_count < 1"
               >
                 <i class="fas fa-trash-alt fa-lg fa-fw"></i>
               </b-btn>


### PR DESCRIPTION
Solves #1043 

Vue js component was modified to show the delete icon just when the category is empty (without associated processes)