### PR TITLE
Redirecting to script builder upon script creation

### DIFF
--- a/resources/views/processes/scripts/index.blade.php
+++ b/resources/views/processes/scripts/index.blade.php
@@ -103,7 +103,7 @@
                     })
                     .then(response => {
                         ProcessMaker.alert('{{__('Script successfully added')}}', 'success');
-                        window.location = "/processes/scripts/" + response.data.id + "/edit";
+                        window.location = "/processes/scripts/" + response.data.id + "/builder";
                     })
                     .catch(error => {
                         this.errors = error.response.data.errors;


### PR DESCRIPTION
We now redirect to the script builder upon script creation rather than the script editor. Closes #1085.

![screen shot 2018-12-20 at 3 46 40 pm](https://user-images.githubusercontent.com/867714/50317086-a9037300-046e-11e9-80b5-7b8923dcb206.png)

![screen shot 2018-12-20 at 3 46 53 pm](https://user-images.githubusercontent.com/867714/50317089-ab65cd00-046e-11e9-8feb-d643a75a0709.png)
