### PR TITLE
Add A Process modal: disable browser autocomplete

### DIFF
--- a/resources/views/processes/index.blade.php
+++ b/resources/views/processes/index.blade.php
@@ -52,7 +52,7 @@
       <div class="modal-body">
         <div class="form-group">
 			{!! Form::label('name', 'Name') !!}
-			{!! Form::text('name', null, ['class'=> 'form-control', 'v-model'=> 'name', 'v-bind:class' => '{\'form-control\':true, \'is-invalid\':addError.name}']) !!}
+			{!! Form::text('name', null, ['autocomplete' => 'off', 'class'=> 'form-control', 'v-model'=> 'name', 'v-bind:class' => '{\'form-control\':true, \'is-invalid\':addError.name}']) !!}
 			<div class="invalid-feedback" v-for="name in addError.name">@{{name}}</div>
         </div>
         <div class="form-group">


### PR DESCRIPTION
Disables the browser's autocomplete feature on Name field of Add A Process modal. Closes #1095.

**Before**
![screen shot 2018-12-26 at 10 05 19 am](https://user-images.githubusercontent.com/867714/50453691-47705800-08f7-11e9-8074-2a8021a67583.png)

**After**
![screen shot 2018-12-26 at 10 13 59 am](https://user-images.githubusercontent.com/867714/50453692-47705800-08f7-11e9-866b-0f4d1fcd3f01.png)
