### PR TITLE
Fix broken avatars

### DIFF
--- a/ProcessMaker/Console/Commands/Install.php
+++ b/ProcessMaker/Console/Commands/Install.php
@@ -140,6 +140,9 @@ class Install extends Command
         $this->call('passport:install', [
             '--force' => true
         ]);
+		
+		//Create a symbolic link from "public/storage" to "storage/app/public"
+		$this->call('storage:link');
 
         $this->info(__("ProcessMaker installation is complete. Please visit the url in your browser to continue."));
         return true;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,6 +14,9 @@ use Illuminate\Support\Facades\Artisan;
 // Bootstrap laravel
 app()->make(Kernel::class)->bootstrap();
 
+//Ensure storage directory is linked
+Artisan::call('storage:link', []);
+
 if (env('RUN_MSSQL_TESTS')) {
     // Setup our testexternal database
     config(['database.connections.testexternal' => [


### PR DESCRIPTION
Solved this issue by calling `storage:link` from the `bpm:install` Artisan command. Also created a test to ensure that avatars can be uploaded and then found in the correct location. Closes #1099.