### PR TITLE
Add password strength meter to Add A User modal

### DIFF
--- a/resources/js/admin/users/index.js
+++ b/resources/js/admin/users/index.js
@@ -1,5 +1,8 @@
 import Vue from 'vue';
+import VuePassword from "vue-password";
 import UsersListing from './components/UsersListing';
+
+Vue.component("vue-password", VuePassword);
 
 new Vue({
     el: '#users-listing',

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -76,15 +76,19 @@
                     </div>
                     <div class="form-group">
                         {!!Form::label('password', __('Password'))!!}
-                        {!!Form::password('password', ['class'=> 'form-control', 'v-model'=> 'password', 'v-bind:class' =>
-                        '{\'form-control\':true, \'is-invalid\':addError.password}'])!!}
-                        <div class="invalid-feedback" v-for="password in addError.password">@{{password}}</div>
+                        <vue-password v-model="password" :disable-toggle=true ref="passwordStrength">
+                            <div slot="password-input" slot-scope="props">
+                                {!!Form::password('password', ['class'=> 'form-control', 'v-model'=> 'password',
+                                '@input' => 'props.updatePassword($event.target.value)',
+                                'v-bind:class' => '{\'form-control\':true, \'is-invalid\':addError.password}'])!!}
+                            </div>
+                        </vue-password>
                     </div>
                     <div class="form-group">
                         {!!Form::label('confpassword', __('Confirm Password'))!!}
                         {!!Form::password('confpassword', ['class'=> 'form-control', 'v-model'=> 'confpassword',
                         'v-bind:class' => '{\'form-control\':true, \'is-invalid\':addError.password}'])!!}
-
+                        <div class="invalid-feedback" v-for="password in addError.password">@{{password}}</div>
                     </div>
                 </div>
                 <div class="modal-footer">
@@ -117,9 +121,19 @@
             },
             methods: {
                 validatePassword() {
+                    if (this.password.trim().length > 0 && this.password.trim().length < 8) {
+                        this.addError.password = ['Password must be at least 8 characters']
+                        this.$refs.passwordStrength.updatePassword('')
+                        this.password = ''
+                        this.confpassword = ''
+                        this.submitted = false
+                        return false
+                    }
                     if (this.password !== this.confpassword) {
                         this.addError.password = ['Passwords must match']
+                        this.$refs.passwordStrength.updatePassword('')
                         this.password = ''
+                        this.confpassword = ''
                         this.submitted = false
                         return false
                     }


### PR DESCRIPTION
Implemented vue-password component as well as password length requirements on Add A User modal on Users index screen. Closes #1104.

![screen shot 2018-12-28 at 10 04 50 am](https://user-images.githubusercontent.com/867714/50523983-0e1b2200-0a88-11e9-93bf-81369dd97cce.png)
