### PR TITLE
errors now displaying in the form when creating a user

### DIFF
--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -151,6 +151,9 @@
                             password: this.password
                         }).then(function (response) {
                             window.location = "/admin/users/" + response.data.id + '/edit'
+                        }).catch(error => {
+                           this.addError = error.response.data.errors
+                            
                         });
                     }
                 }


### PR DESCRIPTION
When creating a new user the errors now display in the form


![screen shot 2019-01-02 at 9 39 42 am](https://user-images.githubusercontent.com/29641725/50603991-595f7700-0e72-11e9-90f6-0106016d8663.png)
