### PR TITLE
Ignore route authorization for notification updates

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/NotificationController.php
+++ b/ProcessMaker/Http/Controllers/Api/NotificationController.php
@@ -14,7 +14,8 @@ use ProcessMaker\Models\User;
 
 class NotificationController extends Controller
 {
-    public $skipPermissionCheckFor = ['index', 'show'];
+    // No need for further authorization since the ID is a guid
+    public $skipPermissionCheckFor = ['index', 'show', 'updateAsRead', 'updateAsUnread'];
 
     /**
      * Display a listing of the resource.

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -60,16 +60,17 @@ window.ProcessMaker = {
      * @param urls
      */
     removeNotifications (messageIds = [], urls = []) {
-        window.ProcessMaker.apiClient.put('/read_notifications', {message_ids: messageIds, routes: urls});
-        messageIds.forEach(function (messageId) {
-            ProcessMaker.notifications.splice(ProcessMaker.notifications.findIndex(x => x.id === messageId), 1);
-        });
+        return window.ProcessMaker.apiClient.put('/read_notifications', {message_ids: messageIds, routes: urls}).then(() => {
+            messageIds.forEach(function (messageId) {
+                ProcessMaker.notifications.splice(ProcessMaker.notifications.findIndex(x => x.id === messageId), 1);
+            });
 
-        urls.forEach(function (url) {
-            let messageIndex = ProcessMaker.notifications.findIndex(x => x.url === url);
-            if (messageIndex >= 0) {
-               ProcessMaker.removeNotification(ProcessMaker.notifications[messageIndex].id);
-            }
+            urls.forEach(function (url) {
+                let messageIndex = ProcessMaker.notifications.findIndex(x => x.url === url);
+                if (messageIndex >= 0) {
+                    ProcessMaker.removeNotification(ProcessMaker.notifications[messageIndex].id);
+                }
+            });
         });
     },
     /**
@@ -81,7 +82,7 @@ window.ProcessMaker = {
      * @param urls
      */
     unreadNotifications (messageIds = [], urls = []) {
-        window.ProcessMaker.apiClient.put('/unread_notifications', {message_ids: messageIds, routes: urls});
+        return window.ProcessMaker.apiClient.put('/unread_notifications', {message_ids: messageIds, routes: urls});
     },
 };
 

--- a/resources/js/notifications/components/NotificationsList.vue
+++ b/resources/js/notifications/components/NotificationsList.vue
@@ -82,13 +82,20 @@
         },
         methods: {
             read(id) {
-                ProcessMaker.removeNotifications([id]);
-                this.fetch();
+                console.log("loading..");
+                ProcessMaker.removeNotifications([id]).then(() => {
+                    console.log("done");
+
+                    this.fetch();
+                });
             },
 
             unread(id){
-                ProcessMaker.unreadNotifications([id]);
-                this.fetch();
+                console.log("loading..");
+                ProcessMaker.unreadNotifications([id]).then(() => {
+                    console.log("done");
+                    this.fetch();
+                });
             },
 
             getSortParam: function () {

--- a/resources/js/notifications/components/NotificationsList.vue
+++ b/resources/js/notifications/components/NotificationsList.vue
@@ -82,18 +82,13 @@
         },
         methods: {
             read(id) {
-                console.log("loading..");
                 ProcessMaker.removeNotifications([id]).then(() => {
-                    console.log("done");
-
                     this.fetch();
                 });
             },
 
             unread(id){
-                console.log("loading..");
                 ProcessMaker.unreadNotifications([id]).then(() => {
-                    console.log("done");
                     this.fetch();
                 });
             },


### PR DESCRIPTION
Fixes #1109

- IDs are guids so we shouldn't need to authorize the user for updates since they would be hard to guess
- Also fixes the read/unread in the list of notifications (clicking on the left mail icon) by returning a promise