### PR TITLE
Notifications showing current time, not actual time of task/notification

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/NotificationController.php
+++ b/ProcessMaker/Http/Controllers/Api/NotificationController.php
@@ -72,6 +72,7 @@ class NotificationController extends Controller
             'data->>message as message',
             'data->>processName as processName',
             'data->>userName as userName',
+            'data->>dateTime as dateTime',
             'data->>request_id as request_id',
             'data->>url as url')
             ->where('notifiable_type', User::class)

--- a/resources/js/notifications/components/NotificationsList.vue
+++ b/resources/js/notifications/components/NotificationsList.vue
@@ -67,8 +67,9 @@
                     },
                     {
                         title: "DATE CREATED",
-                        name: "created_at",
-                        sortField: "created_at"
+                        name: "dateTime",
+                        sortField: "dateTime",
+                        callback: "formatDate"
                     }
                 ]
             };


### PR DESCRIPTION
Solves #1110 

- Notification Controller was modified so that now it sends the dateTime value of the notification's dateTime attribute.
- The notification list was modified to use the dateTime value.