### PR TITLE
Restart queue workers after the install script runs

### DIFF
--- a/ProcessMaker/Console/Commands/Install.php
+++ b/ProcessMaker/Console/Commands/Install.php
@@ -142,7 +142,12 @@ class Install extends Command
         ]);
 		
 		//Create a symbolic link from "public/storage" to "storage/app/public"
-		$this->call('storage:link');
+        $this->call('storage:link');
+        
+        // Restart queue workers so they get the DB credentials
+        $this->info(__(
+            $this->call('queue:restart')
+        ));
 
         $this->info(__("ProcessMaker installation is complete. Please visit the url in your browser to continue."));
         return true;

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     {
         "type": "vcs",
-        "url": "https://github.com/caleeli/bpm-package-email-connector.git"
+        "url": "https://github.com/ProcessMaker/pm4-connector-send-email.git"
     }
   ],
   "require": {

--- a/database/migrations/2019_01_02_210148_create_failed_jobs_table.php
+++ b/database/migrations/2019_01_02_210148_create_failed_jobs_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateFailedJobsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('failed_jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('failed_jobs');
+    }
+}


### PR DESCRIPTION
Fixes #1118

- Queue workers cache the .env so they need to be restarted after we modify it
- Also added a failed_jobs table to debug future errors. I think that table was supposed to be there to begin with since laravel was complaining that it did not exist. Anyway, its useful to have