### PR TITLE
first and last name are now required

### DIFF
--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -119,6 +119,8 @@ class User extends Authenticatable implements HasMedia
         $unique = Rule::unique('users')->ignore($existing);
 
         return [
+            'firstname' => 'required',
+            'lastname' => 'required',
             'username' => ['required', $unique],
             'email' => ['required', 'email', $unique]
         ];

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -65,6 +65,8 @@ class UsersTest extends TestCase
         $url = self::API_TEST_URL;
         $response = $this->apiCall('POST', $url, [
             'username' => 'newuser',
+            'firstname' => 'name',
+            'lastname' => 'name',
             'email' => $faker->email,
             'password' => $faker->sentence(10)
         ]);
@@ -341,6 +343,8 @@ class UsersTest extends TestCase
         //Update the user with the fake image as an avatar
         $putResponse = $this->apiCall('PUT', $url, [
             'username' => $user->username,
+            'firstname' => 'name',
+            'lastname' => 'name',
             'email' => $user->email,
             'avatar' => $avatar,
         ]);


### PR DESCRIPTION
When creating a user their first and last name are now required 
fixes #1126 
![screen shot 2019-01-02 at 2 10 02 pm](https://user-images.githubusercontent.com/29641725/50615130-1ca67680-0e98-11e9-853a-bcd4b2b94157.png)
