### PR TITLE
Installer: adding logo and icon paths to env

### DIFF
--- a/ProcessMaker/Console/Commands/Install.php
+++ b/ProcessMaker/Console/Commands/Install.php
@@ -69,7 +69,10 @@ class Install extends Command
             'BROADCAST_DRIVER' => 'redis',
             'BROADCASTER_KEY' => '21a795019957dde6bcd96142e05d4b10',
             'APP_TIMEZONE' => 'UTC',
-            'DATE_FORMAT' => '"m/d/Y H:i"'
+            'DATE_FORMAT' => '"m/d/Y H:i"',
+            'MAIN_LOGO_PATH' => '"/img/processmaker_logo.png"',
+            'ICON_PATH_PATH' => '"/img/processmaker_icon.png"',
+            'LOGIN_LOGO_PATH' => '"img/processmaker_login.png"'
         ];
 
 


### PR DESCRIPTION
Installer now adds paths to logos and icons to the .env file it creates. Closes #1129.

![screen shot 2019-01-02 at 2 59 32 pm](https://user-images.githubusercontent.com/867714/50616838-0bad3380-0e9f-11e9-9634-3b3a68a6504c.png)
