### PR TITLE
Read Notifications in Inbox

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/NotificationController.php
+++ b/ProcessMaker/Http/Controllers/Api/NotificationController.php
@@ -83,6 +83,8 @@ class NotificationController extends Controller
             $subsearch = '%' . $filter . '%';
             $query->where(function ($query) use ($subsearch, $filter) {
                 $query->Where('data->name', 'like', $subsearch)
+                    ->orWhere('data->userName', 'like', $subsearch)
+                    ->orWhere('data->processName', 'like', $subsearch)
                     ->orWhereRaw("case when read_at is null then 'unread' else 'read' end like '$filter%'");
             });
         }

--- a/resources/js/notifications/components/NotificationsList.vue
+++ b/resources/js/notifications/components/NotificationsList.vue
@@ -131,6 +131,8 @@
                         this.perPage +
                         "&filter=" +
                         this.filter +
+                        "&status=" +
+                        new URLSearchParams(window.location.search).get('status') +
                         this.getSortParam()
                         , {
                             cancelToken: new CancelToken(c => {


### PR DESCRIPTION
Solves #1134 

- Added usage of the status parameter that is sent in the query string.
- Improvement of filtering in the notification list. Now the filter searches by user name, process name, task name and status.