### PR TITLE
Add appropriate autocomplete attributes to username/password inputs

### DIFF
--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -165,7 +165,7 @@
                                     <div class="form-group">
                                         {!! Form::label('username', 'Username') !!}
                                         {!! Form::text('username', null, ['id' => 'username', 'rows' => 4, 'class'=> 'form-control', 'v-model'
-                                        => 'formData.username', 'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.username}']) !!}
+                                        => 'formData.username', 'autocomplete' => 'off', 'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.username}']) !!}
                                         <div class="invalid-feedback" v-if="errors.username">@{{errors.username[0]}}</div>
                                     </div>
 
@@ -186,7 +186,7 @@
 										<vue-password v-model="formData.password" :disable-toggle=true>
 											<div slot="password-input" slot-scope="props">
 												{!! Form::password('password', ['id' => 'password', 'rows' => 4, 'class'=> 'form-control', 'v-model'
-												=> 'formData.password', '@input' => 'props.updatePassword($event.target.value)',
+												=> 'formData.password', 'autocomplete' => 'new-password', '@input' => 'props.updatePassword($event.target.value)',
 												'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.password}']) !!}
 											</div>
 										</vue-password>
@@ -194,7 +194,7 @@
 				                    <div class="form-group">
 				                        {!! Form::label('confPassword', 'Confirm Password') !!}
 				                        {!! Form::password('confPassword', ['id' => 'confPassword', 'rows' => 4, 'class'=> 'form-control', 'v-model'
-				                        => 'formData.confPassword', 'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.password}']) !!}
+				                        => 'formData.confPassword', 'autocomplete' => 'new-password', 'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.password}']) !!}
 										<div class="invalid-feedback" :style="{display: (errors.password) ? 'block' : 'none' }" v-if="errors.password">@{{errors.password[0]}}</div>
 				                    </div>
                                 </div>

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -47,7 +47,7 @@
                     <div class="form-group">
                         {!!Form::label('username', __('Username'))!!}
                         {!!Form::text('username', null, ['class'=> 'form-control', 'v-model'=> 'username', 'v-bind:class'
-                        => '{\'form-control\':true, \'is-invalid\':addError.username}'])!!}
+                        => '{\'form-control\':true, \'is-invalid\':addError.username}', 'autocomplete' => 'off']) !!}
                         <div class="invalid-feedback" v-for="username in addError.username">@{{username}}</div>
                     </div>
                     <div class="form-group">
@@ -71,7 +71,7 @@
                     <div class="form-group">
                         {!!Form::label('email', __('Email'))!!}
                         {!!Form::email('email', null, ['class'=> 'form-control', 'v-model'=> 'email', 'v-bind:class' =>
-                        '{\'form-control\':true, \'is-invalid\':addError.email}'])!!}
+                        '{\'form-control\':true, \'is-invalid\':addError.email}', 'autocomplete' => 'off'])!!}
                         <div class="invalid-feedback" v-for="email in addError.email">@{{email}}</div>
                     </div>
                     <div class="form-group">
@@ -79,7 +79,7 @@
                         <vue-password v-model="password" :disable-toggle=true ref="passwordStrength">
                             <div slot="password-input" slot-scope="props">
                                 {!!Form::password('password', ['class'=> 'form-control', 'v-model'=> 'password',
-                                '@input' => 'props.updatePassword($event.target.value)',
+                                '@input' => 'props.updatePassword($event.target.value)', 'autocomplete' => 'new-password',
                                 'v-bind:class' => '{\'form-control\':true, \'is-invalid\':addError.password}'])!!}
                             </div>
                         </vue-password>
@@ -87,7 +87,7 @@
                     <div class="form-group">
                         {!!Form::label('confpassword', __('Confirm Password'))!!}
                         {!!Form::password('confpassword', ['class'=> 'form-control', 'v-model'=> 'confpassword',
-                        'v-bind:class' => '{\'form-control\':true, \'is-invalid\':addError.password}'])!!}
+                        'v-bind:class' => '{\'form-control\':true, \'is-invalid\':addError.password}', 'autocomplete' => 'new-password'])!!}
                         <div class="invalid-feedback" v-for="password in addError.password">@{{password}}</div>
                     </div>
                 </div>

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -148,7 +148,7 @@
                     <div class="form-group">
                         {!! Form::label('username', 'Username') !!}
                         {!! Form::text('username', null, ['id' => 'username', 'rows' => 4, 'class'=> 'form-control', 'v-model'
-                        => 'formData.username', 'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.username}']) !!}
+                        => 'formData.username', 'autocomplete' => 'off', 'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.username}']) !!}
                         <div class="invalid-feedback" v-if="errors.username">@{{errors.username[0]}}</div>
                     </div>
                     <div class="form-group">
@@ -161,7 +161,7 @@
 						<vue-password v-model="formData.password" :disable-toggle=true>
 							<div slot="password-input" slot-scope="props">
 								{!! Form::password('password', ['id' => 'password', 'rows' => 4, 'class'=> 'form-control', 'v-model'
-								=> 'formData.password', '@input' => 'props.updatePassword($event.target.value)',
+								=> 'formData.password', 'autocomplete' => 'new-password', '@input' => 'props.updatePassword($event.target.value)',
 								'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.password}']) !!}
 							</div>
 						</vue-password>
@@ -169,7 +169,7 @@
                     <div class="form-group">
                         {!! Form::label('confPassword', 'Confirm Password') !!}
                         {!! Form::password('confPassword', ['id' => 'confPassword', 'rows' => 4, 'class'=> 'form-control', 'v-model'
-                        => 'formData.confPassword', 'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.password}']) !!}
+                        => 'formData.confPassword', 'autocomplete' => 'new-password', 'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.password}']) !!}
 						<div class="invalid-feedback" :style="{display: (errors.password) ? 'block' : 'none' }" v-if="errors.password">@{{errors.password[0]}}</div>
                     </div>
                 </div>


### PR DESCRIPTION
Autocomplete = off for email and username fields, autocomplete = new-password for password fields. New-password seems to work more consistently across browsers to prevent autocompletion of password fields. Also allows password managers to suggest high quality passwords. Fixes #1142.