### PR TITLE
Remove setPasswordAttribute from User class. #1166

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -113,7 +113,11 @@ class UserController extends Controller
     {
         $request->validate(User::rules());
         $user = new User();
-        $user->fill($request->json()->all());
+        $fields = $request->json()->all();
+        if (isset($fields['password'])) {
+            $fields['password'] = Hash::make($fields['password']);
+        }
+        $user->fill($fields);
         $user->saveOrFail();
         return new UserResource($user->refresh());
     }

--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -4,10 +4,11 @@ namespace ProcessMaker\Http\Controllers\Api;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
 use ProcessMaker\Http\Controllers\Controller;
 use ProcessMaker\Http\Resources\ApiCollection;
-use ProcessMaker\Models\User;
 use ProcessMaker\Http\Resources\Users as UserResource;
+use ProcessMaker\Models\User;
 
 class UserController extends Controller
 {
@@ -180,7 +181,11 @@ class UserController extends Controller
     public function update(User $user, Request $request)
     {
         $request->validate(User::rules($user));
-        $user->fill($request->json()->all());
+        $fields = $request->json()->all();
+        if (isset($fields['password'])) {
+            $fields['password'] = Hash::make($fields['password']);
+        }
+        $user->fill($fields);
         if (Auth::user()->is_administrator && $request->has('is_administrator')) {
             // user must be an admin to make another user an admin
             $user->is_administrator = $request->get('is_administrator');

--- a/ProcessMaker/Models/User.php
+++ b/ProcessMaker/Models/User.php
@@ -4,7 +4,6 @@ namespace ProcessMaker\Models;
 
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rule;
 use Laravel\Passport\HasApiTokens;
 use Illuminate\Notifications\Notifiable;
@@ -167,18 +166,6 @@ class User extends Authenticatable implements HasMedia
     public function getFullnameAttribute()
     {
         return $this->getFullName();
-    }
-
-    /**
-     * Hashes the password passed as a clear text
-     *
-     * @param $pass
-     */
-    public function setPasswordAttribute($pass)
-    {
-
-        $this->attributes['password'] = Hash::make($pass);
-
     }
 
     /**

--- a/database/seeds/UserSeeder.php
+++ b/database/seeds/UserSeeder.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
 use ProcessMaker\Models\User;
 use ProcessMaker\Models\Group;
 use ProcessMaker\Models\GroupMember;
@@ -28,7 +29,7 @@ class UserSeeder extends Seeder
         //Create admin user
         $user = factory(User::class)->create([
             'username' => 'admin',
-            'password' => 'admin',
+            'password' => Hash::make('admin'),
             'firstname' => 'admin',
             'lastname' => 'admin',
             'timezone' => null,

--- a/tests/Browser/UserCreationTest.php
+++ b/tests/Browser/UserCreationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Browser;
 
 use Barryvdh\Debugbar\Middleware\DebugbarEnabled;
 use DebugBar\DebugBar;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Artisan;
 use ProcessMaker\Models\User;
 use Tests\DuskTestCase;
@@ -20,7 +21,7 @@ class UserCreationTest extends DuskTestCase
         Artisan::call('migrate:fresh', []);
         $user = factory(User::class)->create([
             'username' => 'admin',
-            'password' => 'admin',
+            'password' => Hash::make('admin'),
             'email' => 'any@gmail.com',
             'firstname' => 'admin',
             'lastname' => 'admin',

--- a/tests/Feature/Api/PermissionsTest.php
+++ b/tests/Feature/Api/PermissionsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Api;
 
+use Illuminate\Support\Facades\Hash;
 use Tests\TestCase;
 use ProcessMaker\Models\User;
 use ProcessMaker\Models\Group;
@@ -100,7 +101,7 @@ class PermissionsTest extends TestCase
     public function testSetPermissionsForUser()
     {
         $this->user = factory(User::class)->create([
-            'password' => 'password',
+            'password' => Hash::make('password'),
             'is_administrator' => true,
         ]);
 

--- a/tests/Feature/Api/ProcessPermissionsTest.php
+++ b/tests/Feature/Api/ProcessPermissionsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Api;
 
+use Illuminate\Support\Facades\Hash;
 use ProcessMaker\Models\Group;
 use ProcessMaker\Models\GroupMember;
 use ProcessMaker\Models\User;
@@ -44,7 +45,7 @@ class ProcessPermissionsTest extends TestCase
     {
         $process = factory(Process::class)->create();
         $normal_user = factory(User::class)->create([
-            'password' => 'password'
+            'password' => Hash::make('password')
         ]);
         // User needs the 'global' requests.cancel first
         $normal_user->giveDirectPermission('requests.cancel');
@@ -74,7 +75,7 @@ class ProcessPermissionsTest extends TestCase
     {
         $this->user->is_administrator = true;
         $normal_user = factory(User::class)->create([
-            'password' => 'password'
+            'password' => Hash::make('password')
         ]);
         // User needs the 'global' requests.cancel first
         $normal_user->giveDirectPermission('requests.cancel');

--- a/tests/Feature/Api/ProcessTest.php
+++ b/tests/Feature/Api/ProcessTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Api;
 
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Hash;
 use ProcessMaker\Models\Group;
 use ProcessMaker\Models\GroupMember;
 use ProcessMaker\Models\Permission;
@@ -73,7 +74,7 @@ class ProcessTest extends TestCase
     {
         // We create an user that isn't administrator
         $this->user = factory(User::class)->create([
-            'password' => 'password',
+            'password' => Hash::make('password'),
             'is_administrator' => false,
         ]);
 
@@ -133,7 +134,7 @@ class ProcessTest extends TestCase
     {
         // We create an user that isn't administrator
         $this->user = factory(User::class)->create([
-            'password' => 'password',
+            'password' => Hash::make('password'),
             'is_administrator' => false,
         ]);
 
@@ -203,7 +204,7 @@ class ProcessTest extends TestCase
         ]);
 
         $this->user = factory(User::class)->create([
-            'password' => 'password',
+            'password' => Hash::make('password'),
             'is_administrator' => false,
         ]);
 

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Api;
 
-use Carbon\Carbon;
 use Faker\Factory as Faker;
 use ProcessMaker\Models\User;
 use Tests\TestCase;
@@ -259,7 +258,7 @@ class UsersTest extends TestCase
             'country' => $faker->country,
             'timezone' => $faker->timezone,
             'birthdate' => $faker->dateTimeThisCentury->format('Y-m-d'),
-            'password' => $faker->password(6, 6),
+            'password' => Hash::make($faker->password(6, 6)),
         ]);
 
         //Validate the header status code

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -258,7 +258,7 @@ class UsersTest extends TestCase
             'country' => $faker->country,
             'timezone' => $faker->timezone,
             'birthdate' => $faker->dateTimeThisCentury->format('Y-m-d'),
-            'password' => Hash::make($faker->password(6, 6)),
+            'password' => $faker->password(6, 6),
         ]);
 
         //Validate the header status code

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -34,7 +34,7 @@ class AuthTest extends TestCase
         // Build a user with a specified password
         $user = factory(User::class)->create([
             'username' =>'newuser',
-            'password' => 'password'
+            'password' => Hash::make('password')
         ]);
         // Make sure we have a failed attempt with a bad password
         $this->assertFalse(Auth::attempt([

--- a/tests/Feature/Shared/RequestHelper.php
+++ b/tests/Feature/Shared/RequestHelper.php
@@ -16,7 +16,7 @@ trait RequestHelper
         parent::setUp();
 
         $this->user = factory(User::class)->create([
-            'password' => 'password',
+            'password' => Hash::make('password'),
             'is_administrator' => true,
         ]);
 

--- a/tests/Model/UserTest.php
+++ b/tests/Model/UserTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Tests\Model;
 
+use Illuminate\Support\Facades\Hash;
 use Tests\TestCase;
 use ProcessMaker\Models\User;
 use ProcessMaker\Models\Group;
@@ -12,9 +13,9 @@ class UserTest extends TestCase
 {
 
     public function testPermissions() {
-        $president_user = factory(User::class)->create(['password' => 'password']);
-        $technician_user = factory(User::class)->create(['password' => 'password']);
-        $mom_user = factory(User::class)->create(['password' => 'password']);
+        $president_user = factory(User::class)->create(['password' => Hash::make('password')]);
+        $technician_user = factory(User::class)->create(['password' => Hash::make('password')]);
+        $mom_user = factory(User::class)->create(['password' => Hash::make('password')]);
 
         $ln_permission = factory(Permission::class)->create([
             'guard_name' => 'launch.nukes',


### PR DESCRIPTION
This PR includes the following changes:

- Remove setPasswordAttribute from User class
- Update unit tests
- Update seeder
- Update User controller

Related to: #1166 

```
        // Build a user with a specified password
        $user = factory(User::class)->create([
            'username' =>'newuser',
            'password' => Hash::make('password')
        ]);
```
