### PR TITLE
Show the process in the New Request modal even if it doesn't have a start event

### DIFF
--- a/resources/js/components/requests/card.vue
+++ b/resources/js/components/requests/card.vue
@@ -12,6 +12,19 @@
                 </div>
             </div>
         </div>
+
+        <!-- Temporary until modeler validations are in place -->
+        <div v-if="process.events.length == 0" class="processes">
+            <div class="process-card">
+                <div class="inner">
+                    <div>
+                        <span class="name" v-html="transformedName"></span>
+                    </div>
+                    <div ref="description" class="description warn">This process can not be started because it does not have a start event.</div>
+                </div>
+            </div>
+        </div>
+
     </span>
 </template>
 
@@ -115,6 +128,8 @@ export default {
       color: #788793;
       overflow: hidden;
     }
+
+    .warn { font-style: italic }
   }
 
   &:hover {


### PR DESCRIPTION
Fixes #1188 

Currently the modeler allows you to create a process without a start event, meaning there is no event to kick off in the "New Request" popup modal. This fix shows it even if there are no events.