### PR TITLE
Profile Cancel/Update buttons do not appear depending on window height, #1193

### DIFF
--- a/resources/views/layouts/layout.blade.php
+++ b/resources/views/layouts/layout.blade.php
@@ -55,7 +55,7 @@
 
   <div class="d-flex flex-grow-1 flex-column" style="overflow: hidden;">
     @include('layouts.navbar')
-    <div class="flex-grow-1 d-flex flex-column h-100" id="mainbody">
+    <div class="flex-grow-1 d-flex flex-column h-50" id="mainbody">
       <div class="main flex-grow-1">
         @yield('content')
       </div>


### PR DESCRIPTION
Fixes #1193  

The size of the mainbody div was reduced so that the scroll is displayed correctly in Edge