### PR TITLE
Prevent field injection flaws

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/CommentController.php
+++ b/ProcessMaker/Http/Controllers/Api/CommentController.php
@@ -11,6 +11,15 @@ use ProcessMaker\Models\Comment;
 
 class CommentController extends Controller
 {
+    /**
+     * A blacklist of attributes that should not be
+     * sanitized by our SanitizeInput middleware.
+     *
+     * @var array
+     */
+    public $doNotSanitize = [
+        //
+    ];
 
     /**
      * Display a listing of the resource.

--- a/ProcessMaker/Http/Controllers/Api/CommentController.php
+++ b/ProcessMaker/Http/Controllers/Api/CommentController.php
@@ -12,7 +12,7 @@ use ProcessMaker\Models\Comment;
 class CommentController extends Controller
 {
     /**
-     * A blacklist of attributes that should not be
+     * A whitelist of attributes that should not be
      * sanitized by our SanitizeInput middleware.
      *
      * @var array

--- a/ProcessMaker/Http/Controllers/Api/EnvironmentVariablesController.php
+++ b/ProcessMaker/Http/Controllers/Api/EnvironmentVariablesController.php
@@ -11,6 +11,16 @@ use Illuminate\Http\Request;
 
 class EnvironmentVariablesController extends Controller
 {
+    /**
+     * A blacklist of attributes that should not be
+     * sanitized by our SanitizeInput middleware.
+     *
+     * @var array
+     */
+    public $doNotSanitize = [
+        'value',
+    ];
+
   /**
    * Fetch a collection of variables based on paged request and filter if provided
    *

--- a/ProcessMaker/Http/Controllers/Api/EnvironmentVariablesController.php
+++ b/ProcessMaker/Http/Controllers/Api/EnvironmentVariablesController.php
@@ -12,7 +12,7 @@ use Illuminate\Http\Request;
 class EnvironmentVariablesController extends Controller
 {
     /**
-     * A blacklist of attributes that should not be
+     * A whitelist of attributes that should not be
      * sanitized by our SanitizeInput middleware.
      *
      * @var array

--- a/ProcessMaker/Http/Controllers/Api/FileController.php
+++ b/ProcessMaker/Http/Controllers/Api/FileController.php
@@ -12,6 +12,16 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class FileController extends Controller
 {
     /**
+     * A blacklist of attributes that should not be
+     * sanitized by our SanitizeInput middleware.
+     *
+     * @var array
+     */
+    public $doNotSanitize = [
+        //
+    ];
+
+    /**
      * Display a listing of the resource.
      *
      * @param Request $request

--- a/ProcessMaker/Http/Controllers/Api/FileController.php
+++ b/ProcessMaker/Http/Controllers/Api/FileController.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class FileController extends Controller
 {
     /**
-     * A blacklist of attributes that should not be
+     * A whitelist of attributes that should not be
      * sanitized by our SanitizeInput middleware.
      *
      * @var array

--- a/ProcessMaker/Http/Controllers/Api/GroupController.php
+++ b/ProcessMaker/Http/Controllers/Api/GroupController.php
@@ -12,6 +12,15 @@ use ProcessMaker\Models\User;
 
 class GroupController extends Controller
 {
+    /**
+     * A blacklist of attributes that should not be
+     * sanitized by our SanitizeInput middleware.
+     *
+     * @var array
+     */
+    public $doNotSanitize = [
+        //
+    ];
 
     /**
      * Display a listing of the resource.

--- a/ProcessMaker/Http/Controllers/Api/GroupController.php
+++ b/ProcessMaker/Http/Controllers/Api/GroupController.php
@@ -13,7 +13,7 @@ use ProcessMaker\Models\User;
 class GroupController extends Controller
 {
     /**
-     * A blacklist of attributes that should not be
+     * A whitelist of attributes that should not be
      * sanitized by our SanitizeInput middleware.
      *
      * @var array

--- a/ProcessMaker/Http/Controllers/Api/GroupMemberController.php
+++ b/ProcessMaker/Http/Controllers/Api/GroupMemberController.php
@@ -16,6 +16,16 @@ use ProcessMaker\Http\Resources\GroupMembers as GroupMemberResource;
 class GroupMemberController extends Controller
 {
     /**
+     * A blacklist of attributes that should not be
+     * sanitized by our SanitizeInput middleware.
+     *
+     * @var array
+     */
+    public $doNotSanitize = [
+        //        
+    ];
+
+    /**
      * Display a listing of the resource.
      *
      * @return \Illuminate\Http\Response

--- a/ProcessMaker/Http/Controllers/Api/GroupMemberController.php
+++ b/ProcessMaker/Http/Controllers/Api/GroupMemberController.php
@@ -16,7 +16,7 @@ use ProcessMaker\Http\Resources\GroupMembers as GroupMemberResource;
 class GroupMemberController extends Controller
 {
     /**
-     * A blacklist of attributes that should not be
+     * A whitelist of attributes that should not be
      * sanitized by our SanitizeInput middleware.
      *
      * @var array

--- a/ProcessMaker/Http/Controllers/Api/NotificationController.php
+++ b/ProcessMaker/Http/Controllers/Api/NotificationController.php
@@ -15,7 +15,7 @@ use ProcessMaker\Models\User;
 class NotificationController extends Controller
 {
     /**
-     * A blacklist of attributes that should not be
+     * A whitelist of attributes that should not be
      * sanitized by our SanitizeInput middleware.
      *
      * @var array

--- a/ProcessMaker/Http/Controllers/Api/NotificationController.php
+++ b/ProcessMaker/Http/Controllers/Api/NotificationController.php
@@ -15,6 +15,16 @@ use ProcessMaker\Models\User;
 class NotificationController extends Controller
 {
     /**
+     * A blacklist of attributes that should not be
+     * sanitized by our SanitizeInput middleware.
+     *
+     * @var array
+     */
+    public $doNotSanitize = [
+        'data'
+    ];
+
+    /**
      * Display a listing of the resource.
      *
      * @param Request $request

--- a/ProcessMaker/Http/Controllers/Api/PermissionController.php
+++ b/ProcessMaker/Http/Controllers/Api/PermissionController.php
@@ -12,7 +12,7 @@ use ProcessMaker\Models\Permission;
 class PermissionController extends Controller
 {
     /**
-     * A blacklist of attributes that should not be
+     * A whitelist of attributes that should not be
      * sanitized by our SanitizeInput middleware.
      *
      * @var array

--- a/ProcessMaker/Http/Controllers/Api/PermissionController.php
+++ b/ProcessMaker/Http/Controllers/Api/PermissionController.php
@@ -11,7 +11,15 @@ use ProcessMaker\Models\Permission;
 
 class PermissionController extends Controller
 {
-
+    /**
+     * A blacklist of attributes that should not be
+     * sanitized by our SanitizeInput middleware.
+     *
+     * @var array
+     */
+    public $doNotSanitize = [
+       //
+    ];
     /**
      * Update permissions
      *

--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -21,6 +21,16 @@ use ProcessMaker\Models\User;
 class ProcessController extends Controller
 {
     /**
+     * A blacklist of attributes that should not be
+     * sanitized by our SanitizeInput middleware.
+     *
+     * @var array
+     */
+    public $doNotSanitize = [
+        'bpmn',
+    ];
+
+    /**
      * Get list Process
      *
      * @param Request $request

--- a/ProcessMaker/Http/Controllers/Api/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessController.php
@@ -21,7 +21,7 @@ use ProcessMaker\Models\User;
 class ProcessController extends Controller
 {
     /**
-     * A blacklist of attributes that should not be
+     * A whitelist of attributes that should not be
      * sanitized by our SanitizeInput middleware.
      *
      * @var array

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -18,6 +18,16 @@ use ProcessMaker\Notifications\ProcessCanceledNotification;
 class ProcessRequestController extends Controller
 {
     /**
+     * A blacklist of attributes that should not be
+     * sanitized by our SanitizeInput middleware.
+     *
+     * @var array
+     */
+    public $doNotSanitize = [
+        'data'
+    ];
+    
+    /**
      * Display a listing of the resource.
      *
      * @param Request $request

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -18,7 +18,7 @@ use ProcessMaker\Notifications\ProcessCanceledNotification;
 class ProcessRequestController extends Controller
 {
     /**
-     * A blacklist of attributes that should not be
+     * A whitelist of attributes that should not be
      * sanitized by our SanitizeInput middleware.
      *
      * @var array

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
@@ -26,7 +26,7 @@ use Illuminate\Http\JsonResponse;
 class ProcessRequestFileController extends Controller
 {
     /**
-     * A blacklist of attributes that should not be
+     * A whitelist of attributes that should not be
      * sanitized by our SanitizeInput middleware.
      *
      * @var array

--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestFileController.php
@@ -25,6 +25,18 @@ use Illuminate\Http\JsonResponse;
 
 class ProcessRequestFileController extends Controller
 {
+    /**
+     * A blacklist of attributes that should not be
+     * sanitized by our SanitizeInput middleware.
+     *
+     * @var array
+     */
+    public $doNotSanitize = [
+       'custom_properties',
+       'manipulations',
+       'responsive_images'
+    ];
+
     use HasMediaTrait;
     /*
     * return list of Process Request files

--- a/ProcessMaker/Http/Controllers/Api/ScreenCategoryController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenCategoryController.php
@@ -11,7 +11,7 @@ use ProcessMaker\Http\Resources\ApiResource;
 class ScreenCategoryController extends Controller
 {
     /**
-     * A blacklist of attributes that should not be
+     * A whitelist of attributes that should not be
      * sanitized by our SanitizeInput middleware.
      *
      * @var array

--- a/ProcessMaker/Http/Controllers/Api/ScreenCategoryController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenCategoryController.php
@@ -11,6 +11,16 @@ use ProcessMaker\Http\Resources\ApiResource;
 class ScreenCategoryController extends Controller
 {
     /**
+     * A blacklist of attributes that should not be
+     * sanitized by our SanitizeInput middleware.
+     *
+     * @var array
+     */
+    public $doNotSanitize = [
+        //
+    ];
+
+    /**
      * Display a listing of the Screen Categories.
      *
      * @return \Illuminate\Http\JsonResponse

--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -12,7 +12,7 @@ use ProcessMaker\Http\Resources\ApiCollection;
 class ScreenController extends Controller
 {
     /**
-     * A blacklist of attributes that should not be
+     * A whitelist of attributes that should not be
      * sanitized by our SanitizeInput middleware.
      *
      * @var array

--- a/ProcessMaker/Http/Controllers/Api/ScreenController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScreenController.php
@@ -12,6 +12,16 @@ use ProcessMaker\Http\Resources\ApiCollection;
 class ScreenController extends Controller
 {
     /**
+     * A blacklist of attributes that should not be
+     * sanitized by our SanitizeInput middleware.
+     *
+     * @var array
+     */
+    public $doNotSanitize = [
+        'config',
+    ];
+
+    /**
      * Get a list of Screens.
      *
      * @param Request $request

--- a/ProcessMaker/Http/Controllers/Api/ScriptController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScriptController.php
@@ -11,7 +11,7 @@ use ProcessMaker\Models\Script;
 class ScriptController extends Controller
 {
     /**
-     * A blacklist of attributes that should not be
+     * A whitelist of attributes that should not be
      * sanitized by our SanitizeInput middleware.
      *
      * @var array

--- a/ProcessMaker/Http/Controllers/Api/ScriptController.php
+++ b/ProcessMaker/Http/Controllers/Api/ScriptController.php
@@ -11,6 +11,16 @@ use ProcessMaker\Models\Script;
 class ScriptController extends Controller
 {
     /**
+     * A blacklist of attributes that should not be
+     * sanitized by our SanitizeInput middleware.
+     *
+     * @var array
+     */
+    public $doNotSanitize = [
+        'code',
+    ];
+
+    /**
      * Get a list of scripts in a process.
      *
      * @param Process $process

--- a/ProcessMaker/Http/Controllers/Api/TaskAssignmentController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskAssignmentController.php
@@ -10,6 +10,15 @@ use ProcessMaker\Models\ProcessTaskAssignment;
 
 class TaskAssignmentController extends Controller
 {
+    /**
+     * A blacklist of attributes that should not be
+     * sanitized by our SanitizeInput middleware.
+     *
+     * @var array
+     */
+    public $doNotSanitize = [
+        //
+    ];
 
     /**
      * Display a listing of the resource.

--- a/ProcessMaker/Http/Controllers/Api/TaskAssignmentController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskAssignmentController.php
@@ -11,7 +11,7 @@ use ProcessMaker\Models\ProcessTaskAssignment;
 class TaskAssignmentController extends Controller
 {
     /**
-     * A blacklist of attributes that should not be
+     * A whitelist of attributes that should not be
      * sanitized by our SanitizeInput middleware.
      *
      * @var array

--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -15,6 +15,15 @@ use ProcessMaker\Notifications\TaskReassignmentNotification;
 class TaskController extends Controller
 {
     /**
+     * A blacklist of attributes that should not be
+     * sanitized by our SanitizeInput middleware.
+     *
+     * @var array
+     */
+    public $doNotSanitize = [
+        //
+    ];
+    /**
      * Display a listing of the resource.
      *
      * @param Request $request

--- a/ProcessMaker/Http/Controllers/Api/TaskController.php
+++ b/ProcessMaker/Http/Controllers/Api/TaskController.php
@@ -15,7 +15,7 @@ use ProcessMaker\Notifications\TaskReassignmentNotification;
 class TaskController extends Controller
 {
     /**
-     * A blacklist of attributes that should not be
+     * A whitelist of attributes that should not be
      * sanitized by our SanitizeInput middleware.
      *
      * @var array

--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -13,7 +13,7 @@ use ProcessMaker\Models\User;
 class UserController extends Controller
 {
     /**
-     * A blacklist of attributes that should not be
+     * A whitelist of attributes that should not be
      * sanitized by our SanitizeInput middleware.
      *
      * @var array

--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -13,6 +13,17 @@ use ProcessMaker\Models\User;
 class UserController extends Controller
 {
     /**
+     * A whitelist of attributes that should not be
+     * sanitized by our SanitizeInput middleware.
+     *
+     * @var array
+     */
+    public $doNotSanitize = [
+        'password',
+        'password_confirmation',
+    ];
+
+    /**
      * Display a listing of the resource.
      *
      * @return \Illuminate\Http\Response

--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -13,7 +13,7 @@ use ProcessMaker\Models\User;
 class UserController extends Controller
 {
     /**
-     * A whitelist of attributes that should not be
+     * A blacklist of attributes that should not be
      * sanitized by our SanitizeInput middleware.
      *
      * @var array

--- a/ProcessMaker/Http/Controllers/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/ProcessController.php
@@ -14,7 +14,7 @@ use ProcessMaker\Models\User;
 class ProcessController extends Controller
 {
     /**
-     * A blacklist of attributes that should not be
+     * A whitelist of attributes that should not be
      * sanitized by our SanitizeInput middleware.
      *
      * @var array

--- a/ProcessMaker/Http/Controllers/ProcessController.php
+++ b/ProcessMaker/Http/Controllers/ProcessController.php
@@ -13,6 +13,16 @@ use ProcessMaker\Models\User;
 
 class ProcessController extends Controller
 {
+    /**
+     * A blacklist of attributes that should not be
+     * sanitized by our SanitizeInput middleware.
+     *
+     * @var array
+     */
+    public $doNotSanitize = [
+        'bpmn',
+    ];
+
     public function index(Request $request)
     {
         $status = $request->input('status');

--- a/ProcessMaker/Http/Kernel.php
+++ b/ProcessMaker/Http/Kernel.php
@@ -36,13 +36,12 @@ class Kernel extends HttpKernel
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \ProcessMaker\Http\Middleware\GenerateMenus::class,
             \Laravel\Passport\Http\Middleware\CreateFreshApiToken::class,
+            \ProcessMaker\Http\Middleware\SanitizeInput::class,
 
 
         ],
         'api' => [
-            // Empty middleware for api
-            // @todo Determine if we need throttling.  Currently it interrupts test suites
-            // However, we haven't had a product decision on utilizing throttling or not
+            \ProcessMaker\Http\Middleware\SanitizeInput::class,
         ],
     ];
     /**

--- a/ProcessMaker/Http/Kernel.php
+++ b/ProcessMaker/Http/Kernel.php
@@ -36,12 +36,13 @@ class Kernel extends HttpKernel
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \ProcessMaker\Http\Middleware\GenerateMenus::class,
             \Laravel\Passport\Http\Middleware\CreateFreshApiToken::class,
-            \ProcessMaker\Http\Middleware\SanitizeInput::class,
 
 
         ],
         'api' => [
-            \ProcessMaker\Http\Middleware\SanitizeInput::class,
+            // Empty middleware for api
+            // @todo Determine if we need throttling.  Currently it interrupts test suites
+            // However, we haven't had a product decision on utilizing throttling or not
         ],
     ];
     /**
@@ -59,6 +60,7 @@ class Kernel extends HttpKernel
         'guest' => \ProcessMaker\Http\Middleware\RedirectIfAuthenticated::class,
         'permission' => \ProcessMaker\Http\Middleware\PermissionCheck::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'sanitize' => \ProcessMaker\Http\Middleware\SanitizeInput::class,
         'setlang' => \ProcessMaker\Http\Middleware\SetLanguage::class,
         'setskin' => \ProcessMaker\Http\Middleware\SetSkin::class,
         'session' => \Illuminate\Session\Middleware\StartSession::class,

--- a/ProcessMaker/Http/Middleware/SanitizeInput.php
+++ b/ProcessMaker/Http/Middleware/SanitizeInput.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace ProcessMaker\Http\Middleware;
+
+use Closure;
+use Route;
+use Request;
+use Illuminate\Foundation\Http\Middleware\TransformsRequest;
+
+class SanitizeInput extends TransformsRequest
+{
+    /**
+     * The attributes that should not be sanitized.
+     *
+     * @var array
+     */
+    public $except = [
+        //
+    ];
+
+    /**
+     * Construct the class.
+     */    
+    public function __construct()
+    {
+        // If we have access to the current route...
+        if ($route = Route::current()) {
+            // Get our controller.
+            $controller = $route->controller;
+        
+            // If the controller has a doNotSanitize property,
+            // add it to our exceptions array.
+            if (property_exists($controller, 'doNotSanitize')) {
+                if (is_array($controller->doNotSanitize)) {
+                    $this->except = array_merge($this->except, $controller->doNotSanitize);
+                }
+            }
+        }
+    }
+    
+    /**
+     * Sanitize the given value.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function transform($key, $value)
+    {
+        // If this is a string and is not in the exceptions
+        // array, return it after sanitization.
+        if (is_string($value) && !in_array($key, $this->except, true)) {
+            return e($value);
+        }
+        
+        // Return the original value.
+        return $value;
+    }
+}

--- a/ProcessMaker/Http/Middleware/SanitizeInput.php
+++ b/ProcessMaker/Http/Middleware/SanitizeInput.php
@@ -50,7 +50,15 @@ class SanitizeInput extends TransformsRequest
         // If this is a string and is not in the exceptions
         // array, return it after sanitization.
         if (is_string($value) && !in_array($key, $this->except, true)) {
-            return e($value);
+            // Remove most injectable code
+            $value = strip_tags($value);
+            
+            // Run this for double safety, but we do allow quotes, for example
+            // to allow for users who have names such as Conan O'Brien
+            $value = htmlspecialchars($value, ENT_NOQUOTES, null, true); 
+            
+            // Return the sanitized string
+            return $value;
         }
         
         // Return the original value.

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,7 +1,7 @@
 <?php
 Route::group(
     [
-        'middleware' => ['auth:api', 'bindings'],
+        'middleware' => ['auth:api', 'bindings', 'sanitize'],
         'prefix' => 'api/1.0',
         'namespace' => 'ProcessMaker\Http\Controllers\Api',
         'as' => 'api.',

--- a/routes/web.php
+++ b/routes/web.php
@@ -50,7 +50,6 @@ Route::group(['middleware' => ['auth', 'sanitize']], function () {
 
     Route::get('profile/edit', 'ProfileController@edit')->name('profile.edit');
     Route::get('profile/{id}', 'ProfileController@show')->name('profile.show');
-    Route::put('profile/{id}', 'ProfileController@update')->name('profile.update');
     // Ensure our modeler loads at a distinct url
     Route::get('modeler/{process}', 'Process\ModelerController')->name('modeler.show')->middleware('can:edit-processes');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,7 +2,7 @@
 
 use ProcessMaker\Http\Controllers\Api\Requests\RequestsController;
 
-Route::group(['middleware' => ['auth']], function () {
+Route::group(['middleware' => ['auth', 'sanitize']], function () {
 
 // Routes related to Authentication (password reset, etc)
 // Auth::routes();

--- a/tests/Feature/Api/SanitizationTest.php
+++ b/tests/Feature/Api/SanitizationTest.php
@@ -47,9 +47,6 @@ class SanitizationTest extends TestCase
         // Description should not match since we used restricted characters
         $this->assertNotEquals($description, $data->description);
         
-        // Description should match if we run it through our sanitizer first
-        $this->assertEquals(e($description), $data->description);
-
         // Code should match despite using restricted characters since it is
         // on the sanitization blacklist within the Script API controller
         $this->assertEquals($code, $data->code);

--- a/tests/Feature/Api/SanitizationTest.php
+++ b/tests/Feature/Api/SanitizationTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use Tests\TestCase;
+use Faker\Factory as Faker;
+use ProcessMaker\Models\Script;
+use Tests\Feature\Shared\RequestHelper;
+
+class SanitizationTest extends TestCase
+{
+    use RequestHelper;
+
+    /**
+     * Test our sanitization middleware using a script as our guinea pig.
+     * This allows us to test fields that should be sanitized and
+     * those that should not, all within one model.
+     */
+    public function testSanitizationMiddleware()
+    {
+        // Create our fake data
+        $title = "Best Script Ever";
+        $description = "This is the <b>best</b> script ever!";
+        $code = "<?php echo 'Hello world.';";
+        
+        // Create the process
+        $faker = Faker::create();
+        $script = factory(Script::class)->make([
+            'title' => $title,
+            'description' => $description,
+            'code' => $code,
+        ]);
+
+        // Post the process to the API
+        $response = $this->apiCall('POST', '/scripts', $script->toArray());
+        
+        // Get the new process ID
+        $scriptId = $response->getData()->id;
+        
+        // Reload the script
+        $get = $this->apiCall('GET', "/scripts/{$scriptId}");
+        $data = $get->getData();
+        
+        // Title should match since we did not use any restricted characters
+        $this->assertEquals($title, $data->title);
+
+        // Description should not match since we used restricted characters
+        $this->assertNotEquals($description, $data->description);
+        
+        // Description should match if we run it through our sanitizer first
+        $this->assertEquals(e($description), $data->description);
+
+        // Code should match despite using restricted characters since it is
+        // on the sanitization blacklist within the Script API controller
+        $this->assertEquals($code, $data->code);
+    }
+}


### PR DESCRIPTION
Fixes #1195, which discovered that HTML and JS could potentially be injected into various database fields via the frontend and/or API and then displayed back to users. To mitigate this, we have introduced Sanitize middleware.

- We now strip HTML tags out of all request input by default. This occurs before request input is even accessible to controller methods or models.
- We allow for exceptions by checking for a `$doNotSanitize` property of controllers. This should be an array of field names which will allow all characters to remain in the request input.
- We have a Sanitization unit test which will attempt to pass disallowed characters into various fields and check to ensure the data has been cleaned/not cleaned based on the blacklist.

Here is an example `$doNotSanitize` array from our User API controller. Since we never display passwords back to users and we don't want to alter what they enter, they are added to the list:

```php
/**
 * A blacklist of attributes that should not be
 * sanitized by our SanitizeInput middleware.
 *
 * @var array
 */
public $doNotSanitize = [
    'password',
    'password_confirmation',
];
```