### PR TITLE
Fix 404 errors by allowing middleware to load using Route::fallback

### DIFF
--- a/ProcessMaker/Exception/Handler.php
+++ b/ProcessMaker/Exception/Handler.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Illuminate\Support\Facades\Route;
 
 /**
  * Our general exception handler
@@ -56,7 +57,14 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $exception)
     {
-       return parent::render($request, $exception);
+        if ($exception instanceof NotFoundHttpException) {
+            return Route::respondWithRoute('fallback');
+        }
+
+        if ($exception instanceof ModelNotFoundException) {
+            return Route::respondWithRoute('fallback');
+        }
+        return parent::render($request, $exception);
     }
 
     /**

--- a/ProcessMaker/Http/Kernel.php
+++ b/ProcessMaker/Http/Kernel.php
@@ -33,8 +33,8 @@ class Kernel extends HttpKernel
             // \Illuminate\Session\Middleware\AuthenticateSession::class,   // In case we want to log users out after changing password, we need this
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             //\ProcessMaker\Http\Middleware\VerifyCsrfToken::class,         // This is disabled until all routes are handled by our new engine
-            \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \ProcessMaker\Http\Middleware\GenerateMenus::class,
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \Laravel\Passport\Http\Middleware\CreateFreshApiToken::class,
 
 

--- a/ProcessMaker/Http/Kernel.php
+++ b/ProcessMaker/Http/Kernel.php
@@ -33,8 +33,8 @@ class Kernel extends HttpKernel
             // \Illuminate\Session\Middleware\AuthenticateSession::class,   // In case we want to log users out after changing password, we need this
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             //\ProcessMaker\Http\Middleware\VerifyCsrfToken::class,         // This is disabled until all routes are handled by our new engine
-            \ProcessMaker\Http\Middleware\GenerateMenus::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \ProcessMaker\Http\Middleware\GenerateMenus::class,
             \Laravel\Passport\Http\Middleware\CreateFreshApiToken::class,
 
 

--- a/ProcessMaker/Http/Middleware/GenerateMenus.php
+++ b/ProcessMaker/Http/Middleware/GenerateMenus.php
@@ -103,7 +103,7 @@ class GenerateMenus
                   'icon' => 'fa-clipboard',
               ]);
           }
-       });
+        });
 
         Menu::make('sidebar_processes', function ($menu) {
           $submenu = $menu->add(__('menus.sidebar_processes.processes'));
@@ -150,7 +150,7 @@ class GenerateMenus
               ]);
           }
 
-    });
+        });
 
         Menu::make('sidebar_designer', function ($menu) {});
 

--- a/ProcessMaker/Http/Middleware/SanitizeInput.php
+++ b/ProcessMaker/Http/Middleware/SanitizeInput.php
@@ -30,7 +30,7 @@ class SanitizeInput extends TransformsRequest
         
             // If the controller has a doNotSanitize property,
             // add it to our exceptions array.
-            if (property_exists($controller, 'doNotSanitize')) {
+            if ($controller && property_exists($controller, 'doNotSanitize')) {
                 if (is_array($controller->doNotSanitize)) {
                     $this->except = array_merge($this->except, $controller->doNotSanitize);
                 }

--- a/resources/views/layouts/layout.blade.php
+++ b/resources/views/layouts/layout.blade.php
@@ -34,6 +34,7 @@
     {{-- <link rel="stylesheet" href="https://bootswatch.com/4/darkly/bootstrap.min.css"> --}}
     @yield('css')
     <script type="text/javascript">
+    @if(Auth::user())
     window.Processmaker = {
       csrfToken: "{{csrf_token()}}",
       userId: "{{\Auth::user()->id}}",
@@ -44,6 +45,7 @@
         key: "{{config('broadcasting.key')}}"
       }
     }
+    @endif
   </script>
 </head>
 

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -12,16 +12,16 @@
         </a>
       </li>
     </ul>
-      <ul class="nav flex-column">
-    @foreach($sidebar->topMenu()->items as $section)
-      <li class="section">{{$section->title}}</li>
-      @foreach($section->children() as $item)
-        <li class="nav-item">
-          <a href="{{ $item->url() }}" class="nav-link" title="{{$item->title}}">
-                <i class="fas {{$item->attr('icon')}} nav-icon"></i> <span class="nav-text">{{$item->title}}</span>
-              </a>
-        </li>
+    <ul class="nav flex-column">
+      @foreach($sidebar->topMenu()->items as $section)
+        <li class="section">{{$section->title}}</li>
+        @foreach($section->children() as $item)
+          <li class="nav-item">
+            <a href="{{ $item->url() }}" class="nav-link" title="{{$item->title}}">
+              <i class="fas {{$item->attr('icon')}} nav-icon"></i> <span class="nav-text">{{$item->title}}</span>
+            </a>
+          </li>
         @endforeach
-        @endforeach
-  </ul>
+      @endforeach
+    </ul>
 </div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -128,5 +128,8 @@ Route::group(
     Route::put('comments/{comment}', 'CommentController@update')->name('comments.update')->middleware('can:edit-comments');
     Route::delete('comments/{comment}', 'CommentController@destroy')->name('comments.destroy')->middleware('can:delete-comments');
 
-}
-);
+    // Returns a json error message instead of HTML
+    Route::fallback(function(){
+        return response()->json(['error' => 'Not Found'], 404);
+    });
+});

--- a/routes/api.php
+++ b/routes/api.php
@@ -131,5 +131,5 @@ Route::group(
     // Returns a json error message instead of HTML
     Route::fallback(function(){
         return response()->json(['error' => 'Not Found'], 404);
-    });
+    })->name('fallback');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -72,7 +72,7 @@ Route::group(['middleware' => ['auth', 'sanitize']], function () {
     // Allows for a logged in user to see navigation on a 404 page
     Route::fallback(function(){
         return response()->view('errors.404', [], 404);
-    });
+    })->name('fallback');
 });
 
 // Add our broadcasting routes

--- a/routes/web.php
+++ b/routes/web.php
@@ -69,6 +69,10 @@ Route::group(['middleware' => ['auth', 'sanitize']], function () {
 
     Route::get('notifications', 'NotificationController@index')->name('notifications.index');
 
+    // Allows for a logged in user to see navigation on a 404 page
+    Route::fallback(function(){
+        return response()->view('errors.404', [], 404);
+    });
 });
 
 // Add our broadcasting routes


### PR DESCRIPTION
Fixes #1236 
* When the user is logged in and tries to access something that does not exist
  * A standard 404 page will be rendered
  * This page now has the ability to add navigation with out throwing an error since we are loading middleware (that's for issue #1235 btw)
  * Api will return a json error instead of html
* When NOT logged in
  * Always redirects to login