### PR TITLE
When viewing the request summary screen: "This action is not authorize" #1259

### DIFF
--- a/ProcessMaker/Http/Controllers/RequestController.php
+++ b/ProcessMaker/Http/Controllers/RequestController.php
@@ -88,10 +88,11 @@ class RequestController extends Controller
         $request->summary = $request->summary();
         $request->summary_screen = $request->getSummaryScreenId();
         $canCancel = Auth::user()->can('cancel', $request->process);
+        $canViewComments = Auth::user()->hasPermissionsFor('comments')->count() > 0;
 
         $files = $request->getMedia();
 
-        return view('requests.show', compact('request', 'files', 'canCancel'));
+        return view('requests.show', compact('request', 'files', 'canCancel', 'canViewComments'));
     }
 
     public function downloadFiles(ProcessRequest $requestID, Media $fileID)

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -137,9 +137,11 @@
                     </div>
                 </div>
 
+                @if($canViewComments === true)
                 <div>
                     <comments commentable_id="{{ $request->getKey() }}" commentable_type="{{ get_class($request) }}" />
                 </div>
+                @endif
 
             </div>
             <div class="col-md-4">


### PR DESCRIPTION
If the user hasn't the comments permission, the comments list component is not rendered.
 fixes #1259 