### PR TITLE
Correctly display errors when creating/editing auth clients

### DIFF
--- a/resources/js/admin/auth-clients/index.js
+++ b/resources/js/admin/auth-clients/index.js
@@ -11,6 +11,10 @@ new Vue({
                 redirect: "",
                 secret: "",
             },
+            errors: {
+                name: null,
+                redirect: null,
+            },
         }
     },
     components: {AuthClientsListing},
@@ -23,7 +27,8 @@ new Vue({
             this.authClient = {id: null, name: '', redirect: '', secret: null}
             this.$refs.createEditAuthClient.show()
         },
-        save() {
+        save(event) {
+            event.preventDefault()
             this.loading = true
             let method = 'POST'
             let url = '/oauth/clients'
@@ -40,8 +45,14 @@ new Vue({
             }).then(response => {
                 this.$refs.createEditAuthClient.hide()
                 this.$refs.authClientList.fetch()
+                this.resetValues();
                 this.loading = false
+            }).catch(error => {
+                this.errors = error.response.data.errors
             });
+        },
+        resetValues() {
+            this.errors = { name: null, redirect: null }
         }
     },
     computed: {

--- a/resources/views/admin/auth-clients/index.blade.php
+++ b/resources/views/admin/auth-clients/index.blade.php
@@ -26,17 +26,19 @@
         </div>
     </div>
     <div>
-        <b-modal ref="createEditAuthClient" :title="modalTitle" @ok="save" ok-title="Save" cancel-title="Close">
-            <div class="form-group">
+        <b-modal ref="createEditAuthClient" :title="modalTitle" @ok="save" @hidden="resetValues" ok-title="Save" cancel-title="Close">
+        <div class="form-group">
                 <label for="authClientName">{{__('Name')}}</label>
-                <b-form-input id="authClientName" v-model="authClient.name" type="text" placeholder="Enter a name for this auth client"></b-form-input>
+                <b-form-input id="authClientName" v-bind:class="{'is-invalid':errors.name}" v-model="authClient.name" type="text" placeholder="Enter a name for this auth client"></b-form-input>
+                <div class="invalid-feedback" v-if="errors.name">@{{ errors.name[0] }}</div>
             </div>
             <div class="form-group">
-                <label for="authClientName">{{__('Redirect URL')}}</label>
-                <b-form-input v-model="authClient.redirect" type="text" placeholder="Enter the URL to redirect to"></b-form-input>
+                <label for="authClientRedirect">{{__('Redirect URL')}}</label>
+                <b-form-input id="authClientRedirect" v-bind:class="{'is-invalid':errors.redirect}" v-model="authClient.redirect" type="text" placeholder="Enter the URL to redirect to"></b-form-input>
+                <div class="invalid-feedback" v-if="errors.redirect">@{{ errors.redirect[0] }}</div>
             </div>
             <div v-if="authClient.secret" class="form-group">
-                <label for="authClientName">{{__('Client Secret')}}</label>
+                <label for="authClientSecret">{{__('Client Secret')}}</label>
                 @{{ authClient.secret }}
             </div>
         </b-modal>


### PR DESCRIPTION
Fixes #1251 

- Uses the convention we are using in other modals to display errors on edit and create