### PR TITLE
 500 error when making Group name larger than 256 characters #1256 

### DIFF
--- a/ProcessMaker/Models/Group.php
+++ b/ProcessMaker/Models/Group.php
@@ -44,7 +44,7 @@ class Group extends Model
         $unique = Rule::unique('groups')->ignore($existing);
 
         return [
-            'name' => ['required', 'string', $unique],
+            'name' => ['required', 'string', 'max:255', $unique],
             'status' => 'in:ACTIVE,INACTIVE'
         ];
     }

--- a/resources/views/admin/groups/edit.blade.php
+++ b/resources/views/admin/groups/edit.blade.php
@@ -33,7 +33,8 @@
                         {!! Form::open() !!}
                         <div class="form-group">
                             {!! Form::label('name', 'Name') !!}
-                            {!! Form::text('name', null, ['id' => 'name','class'=> 'form-control', 'v-model' => 'formData.name', 'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.name}']) !!}
+                            {!! Form::text('name', null, ['id' => 'name','class'=> 'form-control', 'maxlength' => '255',
+                            'v-model' => 'formData.name', 'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.name}']) !!}
                             <small class="form-text text-muted">Group name must be distinct</small>
                             <div class="invalid-feedback" v-if="errors.name">@{{errors.name[0]}}</div>
                         </div>

--- a/resources/views/admin/groups/index.blade.php
+++ b/resources/views/admin/groups/index.blade.php
@@ -51,8 +51,8 @@
                     <div class="modal-body">
                         <div class="form-group">
                             {!! Form::label('name', 'Name') !!}
-                            {!! Form::text('name', null, ['id' => 'name','class'=> 'form-control', 'v-model' =>
-                            'formData.name', 'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.name}']) !!}
+                            {!! Form::text('name', null, ['id' => 'name','class'=> 'form-control', 'maxlength' => '255',
+                            'v-model' => 'formData.name', 'v-bind:class' => '{\'form-control\':true, \'is-invalid\':errors.name}']) !!}
                             <small id="emailHelp" class="form-text text-muted">Group name must be distinct</small>
                             <div class="invalid-feedback" v-for="name in errors.name">@{{name}}</div>
                         </div>


### PR DESCRIPTION
- The model has a validation to limit the number of characters, so no error 500 (that was caused because the long string was truncated) is generated.
- In the new group and edit screens the name field now have a max length limitation.

Fixes #1256.