### PR TITLE
Changing Homestead version to 6.4.0

### DIFF
--- a/Homestead.yaml
+++ b/Homestead.yaml
@@ -2,6 +2,8 @@ ip: 192.168.10.10
 memory: 2048
 cpus: 1
 provider: virtualbox
+box: laravel/homestead
+version: 6.4.0
 authorize: ~/.ssh/id_rsa.pub
 keys:
     - ~/.ssh/id_rsa


### PR DESCRIPTION
We need to maintain PHP 7.2 as our default version, so we have specified that we need Homestead version 6.4.0. Fixes #1210.