### PR TITLE
Passing type field when updating screens

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -185,6 +185,7 @@
                     .put("screens/" + this.screen.id, {
                         title: this.screen.title,
                         description: this.screen.description,
+                        type: this.screen.type,
                         config: this.config,
                         computed: this.computed
                     })


### PR DESCRIPTION
To bypass validation error that prevented screens from being saved in the screen builder. Fixes #1273.