### PR TITLE
Docker executors are installed during Vagrant provision

### DIFF
--- a/after.sh
+++ b/after.sh
@@ -24,6 +24,12 @@ sudo usermod -a -G docker vagrant
 # Restart PHP, to ensure that it picks up the new group membership
 sudo service php7.2-fpm restart
 
+# Install docker executors
+docker pull processmaker/executor:php
+docker pull processmaker/executor:lua
+sudo mkdir -m777 /opt/executor
+sudo docker-php-ext-enable xdebug
+
 # Install echo server which will help run socket.io locally
 sudo npm install -g laravel-echo-server
 

--- a/after.sh
+++ b/after.sh
@@ -25,10 +25,9 @@ sudo usermod -a -G docker vagrant
 sudo service php7.2-fpm restart
 
 # Install docker executors
-docker pull processmaker/executor:php
-docker pull processmaker/executor:lua
+sudo docker pull processmaker/executor:php
+sudo docker pull processmaker/executor:lua
 sudo mkdir -m777 /opt/executor
-sudo docker-php-ext-enable xdebug
 
 # Install echo server which will help run socket.io locally
 sudo npm install -g laravel-echo-server


### PR DESCRIPTION
Added a step to install processmaker/executor:php and processmaker/executor:lua when our Vagrant provisioner is run. This fixes issues with running requests after a clean install. Fixes #1290.