### PR TITLE
Removing old references to disabledForNow

### DIFF
--- a/resources/views/admin/groups/edit.blade.php
+++ b/resources/views/admin/groups/edit.blade.php
@@ -127,8 +127,7 @@
                         <div class="modal-footer">
                             <button type="button" class="btn btn-outline-success"
                                     data-dismiss="modal" @click="onCloseAddUser">{{__('Close')}}</button>
-                            <button type="button" class="btn btn-success ml-2" @click="onSave"
-                                    id="disabledForNow">{{__('Save')}}</button>
+                            <button type="button" class="btn btn-success ml-2" @click="onSave">{{__('Save')}}</button>
                         </div>
                     </div>
                 </div>

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -102,8 +102,7 @@
                     <div class="modal-footer">
                         <button type="button" class="btn btn-outline-success"
                                 data-dismiss="modal" @click="onClose">{{__('Close')}}</button>
-                        <button type="button" class="btn btn-success ml-2" @click="onSubmit"
-                                id="disabledForNow">{{__('Save')}}</button>
+                        <button type="button" class="btn btn-success ml-2" @click="onSubmit">{{__('Save')}}</button>
                     </div>
                 </div>
             </div>

--- a/resources/views/processes/categories/index.blade.php
+++ b/resources/views/processes/categories/index.blade.php
@@ -60,8 +60,7 @@
                     <div class="modal-footer">
                         <button type="button" class="btn btn-outline-success"
                                 data-dismiss="modal" @click="onClose">{{__('Close')}}</button>
-                        <button type="button" class="btn btn-success ml-2" @click="onSubmit"
-                                id="disabledForNow">{{__('Save')}}</button>
+                        <button type="button" class="btn btn-success ml-2" @click="onSubmit">{{__('Save')}}</button>
                     </div>
                 </div>
 

--- a/resources/views/processes/environment-variables/index.blade.php
+++ b/resources/views/processes/environment-variables/index.blade.php
@@ -71,8 +71,7 @@
                     <div class="modal-footer">
                         <button type="button" class="btn btn-outline-success"
                                 data-dismiss="modal" @click="onClose">{{__('Close')}}</button>
-                        <button type="button" class="btn btn-success ml-2" @click="onSubmit"
-                                id="disabledForNow">{{__('Save')}}</button>
+                        <button type="button" class="btn btn-success ml-2" @click="onSubmit">{{__('Save')}}</button>
                     </div>
                 </div>
 

--- a/resources/views/processes/index.blade.php
+++ b/resources/views/processes/index.blade.php
@@ -86,7 +86,7 @@
             </div>
         	<div class="modal-footer">
     			<button type="button" class="btn btn-outline-success" data-dismiss="modal" v-if='processCategories' @click="onClose">Close</button>
-    			<button type="button" class="btn btn-success ml-2" id="disabledForNow" @click="onSubmit" v-if='processCategories'>Save</button>
+    			<button type="button" class="btn btn-success ml-2" @click="onSubmit" v-if='processCategories'>Save</button>
             </div>
         </div>
         </div>

--- a/resources/views/processes/scripts/index.blade.php
+++ b/resources/views/processes/scripts/index.blade.php
@@ -73,7 +73,7 @@
                     <button type="button" class="btn btn-outline-success"
                             data-dismiss="modal" @click="onClose">{{__('Close')}}
                     </button>
-                    <button type="button" class="btn btn-success ml-2" id="disabledForNow" @click="onSubmit">
+                    <button type="button" class="btn btn-success ml-2" @click="onSubmit">
                         {{__('Save')}}
                     </button>
                 </div>


### PR DESCRIPTION
Several buttons throughout the codebase had the ID "disabledForNow" even though they were no longer disabled. This removes those IDs and closes #1291.