### PR TITLE
Add Previous Task Assignee Rule

### DIFF
--- a/ProcessMaker/AssignmentRules/PreviousTaskAssignee.php
+++ b/ProcessMaker/AssignmentRules/PreviousTaskAssignee.php
@@ -28,7 +28,9 @@ class PreviousTaskAssignee implements AssignmentRuleInterface
      */
     public function getNextUser(ActivityInterface $task, TokenInterface $token, Process $process, ProcessRequest $request)
     {
-        $previous = $request->tokens()->orderBy('id', 'desc')->first();
+        $previous = $request->tokens()
+            ->where('element_type', 'task')
+            ->orderBy('id', 'desc')->first();
         return $previous->user_id;
     }
 }

--- a/ProcessMaker/AssignmentRules/PreviousTaskAssignee.php
+++ b/ProcessMaker/AssignmentRules/PreviousTaskAssignee.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace ProcessMaker\AssignmentRules;
+
+use ProcessMaker\Contracts\AssignmentRuleInterface;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
+
+/**
+ * Before a task is assigned, search the tokens table for a previously assigned
+ * task and use that users id for the new assignment.
+ *
+ */
+class PreviousTaskAssignee implements AssignmentRuleInterface
+{
+
+    /**
+     * Before a task is assigned, search the tokens table for a previously
+     * assigned task and use that users id for the new assignment.
+     *
+     * @param ActivityInterface $task
+     * @param TokenInterface $token
+     * @param Process $process
+     * @param ProcessRequest $request
+     * @return type
+     */
+    public function getNextUser(ActivityInterface $task, TokenInterface $token, Process $process, ProcessRequest $request)
+    {
+        $previous = $request->tokens()->orderBy('id', 'desc')->first();
+        return $previous->user_id;
+    }
+}

--- a/ProcessMaker/Contracts/AssignmentRuleInterface.php
+++ b/ProcessMaker/Contracts/AssignmentRuleInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace ProcessMaker\Contracts;
+
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
+use ProcessMaker\Nayra\Contracts\Bpmn\TokenInterface;
+
+interface AssignmentRuleInterface
+{
+
+    /**
+     * Return the user id to which a task must be assigned.
+     *
+     * @param ActivityInterface $activity
+     * @param TokenInterface $token
+     * @param Process $process
+     * @param ProcessRequest $request
+     *
+     * @return string User id
+     */
+    public function getNextUser(ActivityInterface $activity, TokenInterface $token, Process $process, ProcessRequest $request);
+}

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\Rule;
+use ProcessMaker\AssignmentRules\PreviousTaskAssignee;
 use ProcessMaker\Exception\TaskDoesNotHaveUsersException;
 use ProcessMaker\Models\ProcessRequestToken;
 use ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface;
@@ -13,10 +14,10 @@ use ProcessMaker\Nayra\Contracts\Bpmn\ScriptTaskInterface;
 use ProcessMaker\Nayra\Contracts\Bpmn\ServiceTaskInterface;
 use ProcessMaker\Nayra\Contracts\Storage\BpmnDocumentInterface;
 use ProcessMaker\Nayra\Storage\BpmnDocument;
+use ProcessMaker\Traits\ProcessTaskAssignmentsTrait;
 use ProcessMaker\Traits\SerializeToIso8601;
 use Spatie\MediaLibrary\HasMedia\HasMedia;
 use Spatie\MediaLibrary\HasMedia\HasMediaTrait;
-use ProcessMaker\Traits\ProcessTaskAssignmentsTrait;
 
 /**
  * Represents a business process definition.
@@ -291,6 +292,10 @@ class Process extends Model implements HasMedia
                 break;
             case 'requestor':
                 $user = $token->getInstance()->user_id;
+                break;
+            case 'previous_task_assignee':
+                $rule = new PreviousTaskAssignee();
+                $user = $rule->getNextUser($activity, $token, $this, $token->processRequest);
                 break;
             case 'manual':
             case 'self_service':

--- a/ProcessMaker/Models/Process.php
+++ b/ProcessMaker/Models/Process.php
@@ -295,7 +295,7 @@ class Process extends Model implements HasMedia
                 break;
             case 'previous_task_assignee':
                 $rule = new PreviousTaskAssignee();
-                $user = $rule->getNextUser($activity, $token, $this, $token->processRequest);
+                $user = $rule->getNextUser($activity, $token, $this, $token->getInstance());
                 break;
             case 'manual':
             case 'self_service':

--- a/resources/js/processes/modeler/components/inspector/TaskAssignment.vue
+++ b/resources/js/processes/modeler/components/inspector/TaskAssignment.vue
@@ -16,6 +16,7 @@
                 <option value="requestor">To requestor</option>
                 <option value="user">To user</option>
                 <option value="group">To group</option>
+                <option value="previous_task_assignee">Previous task assignee</option>
             </select>
         </div>
 

--- a/tests/Feature/Api/TaskAssignmentPreviousOwnerTest.php
+++ b/tests/Feature/Api/TaskAssignmentPreviousOwnerTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use ProcessMaker\Facades\WorkflowManager;
+use ProcessMaker\Models\Process;
+use ProcessMaker\Models\ProcessRequest;
+use ProcessMaker\Models\ProcessRequestToken;
+use ProcessMaker\Models\User;
+use Tests\Feature\Shared\RequestHelper;
+use Tests\TestCase;
+
+class TaskAssignmentPreviousOwnerTest extends TestCase
+{
+
+    use RequestHelper;
+
+    /**
+     * @var Process $process
+     */
+    protected $process;
+
+    /**
+     * @var \ProcessMaker\Nayra\Contracts\Bpmn\ActivityInterface $task
+     */
+    protected $task;
+
+    /**
+     * @var \ProcessMaker\Models\User $assigned
+     */
+    protected $assigned;
+
+    /**
+     * @var array $requestStructure
+     */
+    private $requestStructure = [
+        'id',
+        'process_id',
+        'user_id',
+        'status',
+        'name',
+        'initiated_at',
+        'created_at',
+        'updated_at'
+    ];
+
+    /**
+     * Create new task assignment type user successfully
+     */
+    private function loadTestProcessPreviousUserAssignment()
+    {
+        // Create a new process
+        $this->process = factory(Process::class)->create();
+
+        // Load a single task process
+        $this->process->bpmn = file_get_contents(__DIR__ . '/processes/PreviousTaskAssignee.bpmn');
+
+        // Create user to be assigned to the task
+        $task_uid = 'UserTaskUID';
+        $this->task = $this->process->getDefinitions()->getActivity($task_uid);
+        $this->assigned = factory(User::class)->create([
+            'id' => $this->task->getProperty('assignedUsers'),
+            'status' => 'ACTIVE',
+        ]);
+
+        // When save the process creates the assignments
+        $this->process->save();
+    }
+
+    /**
+     * Execute a process with single user assignment
+     */
+    public function testSingleUserAssignment()
+    {
+        $this->loadTestProcessPreviousUserAssignment();
+
+        // Start a process request
+        $route = route('api.process_events.trigger',
+            [$this->process->id, 'event' => 'StartEventUID']);
+        $data = [];
+        $response = $this->apiCall('POST', $route, $data);
+
+        // Verify status
+        $response->assertStatus(201);
+
+        // Verify the structure
+        $response->assertJsonStructure($this->requestStructure);
+        $request = $response->json();
+
+        $requestId = $request['id'];
+
+        $request = ProcessRequest::find($requestId);
+
+        // Token 0: user of event start
+        $this->assertEquals($request->tokens[0]->user_id, $this->user->id);
+
+        // Token 1: user of task
+        $this->assertEquals($request->tokens[1]->user_id, $this->assigned->id);
+
+        // Complete task
+        $this->completeTask($request->tokens[1]);
+
+        // Reload request
+        $request = ProcessRequest::find($requestId);
+        
+        // Verify assigned user is the same of the previous task
+        $this->assertEquals($request->tokens[1]->user_id, $request->tokens[2]->user_id);
+    }
+
+    /**
+     * Complete task
+     *
+     * @param \ProcessMaker\Models\ProcessRequestToken $task
+     * @param array $data
+     *
+     * @return \ProcessMaker\Models\ProcessRequestToken
+     */
+    private function completeTask(ProcessRequestToken $task, $data = [])
+    {
+        //Call the manager to trigger the start event
+        $process = $task->process;
+        $instance = $task->processRequest;
+        WorkflowManager::completeTask($process, $instance, $task, $data);
+        return $task->refresh();
+    }
+}

--- a/tests/Feature/Api/processes/PreviousTaskAssignee.bpmn
+++ b/tests/Feature/Api/processes/PreviousTaskAssignee.bpmn
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1537370422571" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:yaoqiang="http://bpmn.sourceforge.net" exporter="Yaoqiang BPMN Editor" exporterVersion="5.3" expressionLanguage="http://www.w3.org/1999/XPath" id="_1549289076597" name="" targetNamespace="http://sourceforge.net/bpmn/definitions/_1537370422571" typeLanguage="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <process id="PROCESS_1" isClosed="false" isExecutable="true" processType="None">
+    <extensionElements>
+      <yaoqiang:description/>
+      <yaoqiang:pageFormat height="841.8897637795276" imageableHeight="831.8897637795276" imageableWidth="588.1102362204724" imageableX="5.0" imageableY="5.0" orientation="0" width="598.1102362204724"/>
+      <yaoqiang:page background="#FFFFFF" horizontalCount="1" verticalCount="1"/>
+    </extensionElements>
+    <userTask completionQuantity="1" id="UserTaskUID" implementation="##unspecified" isForCompensation="false" name="Task 1" pm:assignedUsers="55" pm:assignment="user" startQuantity="1">
+      <incoming>_4</incoming>
+      <outgoing>_3</outgoing>
+    </userTask>
+    <sequenceFlow id="_4" sourceRef="StartEventUID" targetRef="UserTaskUID"/>
+    <startEvent id="StartEventUID" isInterrupting="true" name="Start Event" parallelMultiple="false">
+      <outgoing>_4</outgoing>
+      <outputSet/>
+    </startEvent>
+    <userTask completionQuantity="1" id="_2" implementation="##unspecified" isForCompensation="false" name="Task 2" pm:assignment="previous_task_assignee" startQuantity="1">
+      <incoming>_3</incoming>
+      <outgoing>_5</outgoing>
+    </userTask>
+    <endEvent id="EndEventUID" name="End Event">
+      <incoming>_5</incoming>
+      <inputSet/>
+    </endEvent>
+    <sequenceFlow id="_3" sourceRef="UserTaskUID" targetRef="_2"/>
+    <sequenceFlow id="_5" sourceRef="_2" targetRef="EndEventUID"/>
+  </process>
+  <bpmndi:BPMNDiagram id="Yaoqiang_Diagram-PROCESS_1" name="Untitled Diagram" resolution="96.0">
+    <bpmndi:BPMNPlane bpmnElement="PROCESS_1">
+      <bpmndi:BPMNShape bpmnElement="UserTaskUID" id="Yaoqiang-UserTaskUID">
+        <dc:Bounds height="55.0" width="85.0" x="174.0" y="58.5"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.96" width="41.0" x="196.0" y="78.52"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="StartEventUID" id="Yaoqiang-StartEventUID">
+        <dc:Bounds height="32.0" width="32.0" x="98.49999999999989" y="70.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.96" width="63.0" x="83.0" y="110.53"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_2" id="Yaoqiang-_2">
+        <dc:Bounds height="55.0" width="85.0" x="307.0" y="58.5"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.96" width="41.0" x="329.0" y="78.52"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="EndEventUID" id="Yaoqiang-EndEventUID">
+        <dc:Bounds height="32.0" width="32.0" x="439.0" y="70.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.96" width="58.0" x="426.0" y="110.52"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="_5" id="Yaoqiang-_5">
+        <di:waypoint x="392.0" y="86.0"/>
+        <di:waypoint x="439.0078144082805" y="86.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.96" width="6.0" x="412.5" y="76.52"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_4" id="Yaoqiang-_4">
+        <di:waypoint x="129.99218559171948" y="86.0"/>
+        <di:waypoint x="174.0" y="86.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.96" width="6.0" x="149.0" y="76.52"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_3" id="Yaoqiang-_3">
+        <di:waypoint x="259.0" y="86.0"/>
+        <di:waypoint x="307.0" y="86.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="18.96" width="6.0" x="280.0" y="76.52"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>


### PR DESCRIPTION
This PR includes:

- Add an option in the Modeler to use "Previous Task Assignee Rule" in the tasks
- Add the Previous Task Assignee Rule
- Add unit tests to validate this rule.

![image](https://user-images.githubusercontent.com/8028650/52213848-a0240080-2866-11e9-802b-27b37fec35cc.png)

Related: #1309 
