### PR TITLE
Server Error when adding task assignment without target #1332

### DIFF
--- a/resources/lang/en/exceptions.php
+++ b/resources/lang/en/exceptions.php
@@ -1,6 +1,6 @@
 <?php
 return [
-    'TaskDoesNotHaveUsersException' => 'The task ":task" does not have any assigned user',
+    'TaskDoesNotHaveUsersException' => 'The task ":task" has an incomplete assignment. You should select one user or group.',
     'ScriptLanguageNotSupported' => 'The ":language" language is not supported',
     'SyntaxErrorException' => 'Syntax error. :error',
     'ExpressionFailedException' => 'Failed to evaluate expression. :error',


### PR DESCRIPTION
This ticket solves #1332 

- The error message was improved to instruct to the user that he should select one specific user or group when using a group or user assignment.
- If the assignment is incorrect the server responds with status 422 instead of 500 as before.