### PR TITLE
Edit Data Permissions

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
+++ b/ProcessMaker/Http/Controllers/Api/ProcessRequestController.php
@@ -199,7 +199,7 @@ class ProcessRequestController extends Controller
         }
         $fields = $httpRequest->json()->all();
         if (array_keys($fields) === ['data']) {
-            if (! Auth::user()->can('editData', $request->process)) {
+            if (! Auth::user()->can('editData', $request)) {
                 throw new AuthorizationException(__('Not authorized to edit request data.'));
             }
             // Update data edited

--- a/ProcessMaker/Policies/ProcessRequestPolicy.php
+++ b/ProcessMaker/Policies/ProcessRequestPolicy.php
@@ -67,4 +67,26 @@ class ProcessRequestPolicy
             return true;
         }
     }
+    
+    /**
+     * Determine whether the user can edit request data.
+     *
+     * @param  \ProcessMaker\Models\User  $user
+     * @param  \ProcessMaker\Process  $process
+     * @return boolean
+     */    
+    public function editData(User $user, ProcessRequest $request)
+    {
+        if ($request->status === 'ACTIVE') {
+            $permission = 'edit-task_data';
+        } else {
+            $permission = 'edit-request_data';
+        }
+        
+        if ($user->can($permission)) {
+            return true;
+        }
+        
+        return $user->can('editData', $request->process);
+    }
 }

--- a/database/seeds/PermissionSeeder.php
+++ b/database/seeds/PermissionSeeder.php
@@ -57,7 +57,9 @@ class PermissionSeeder extends Seeder
         'create-auth_clients',
         'view-auth_clients',
         'edit-auth_clients',
-        'delete-auth_clients'
+        'delete-auth_clients',
+        'edit-request_data',
+        'edit-task_data',
     ];
     
     public function run($seedUser = null)

--- a/resources/views/admin/shared/permissions.blade.php
+++ b/resources/views/admin/shared/permissions.blade.php
@@ -9,6 +9,8 @@
     <div id="requests" class="collapse" >
         <div class="card-body">
             <label><input type="checkbox" :disabled="formData.is_administrator" value="view-all_requests" v-model="selectedPermissions">   {{__('View All Requests')}}</label>
+            <label><input type="checkbox" :disabled="formData.is_administrator" value="edit-request_data" v-model="selectedPermissions">   {{__('Edit Request Data')}}</label>
+            <label><input type="checkbox" :disabled="formData.is_administrator" value="edit-task_data" v-model="selectedPermissions">   {{__('Edit Task Data')}}</label>
         </div>
     </div>
 </div>

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -42,7 +42,7 @@
                                 </a>
                             </li>
                             @if ($request->status === 'COMPLETED')
-                            @can('editData', $request->process)
+                            @can('editData', $request)
                             <li>
                                 <a id="editdata-tab" data-toggle="tab" href="#editdata" role="tab"
                                    aria-controls="editdata" aria-selected="false"
@@ -118,7 +118,7 @@
                             </template>
                         </div>
                         @if ($request->status === 'COMPLETED')
-                        @can('editData', $request->process)
+                        @can('editData', $request)
                         <div id="editdata" role="tabpanel" aria-labelledby="editdata" class="tab-pane">
                             @include('tasks.editdata')
                         </div>

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -31,14 +31,14 @@
             <div class="col-md-8">
                 <div class="container-fluid">
 
-                    <ul id="tabHeader" role="tablist" class="nav nav-tabs">
-                        <li class="nav-item"><a id="pending-tab" data-toggle="tab" href="#tab-form" role="tab" aria-controls="tab-form" aria-selected="true" class="nav-link active">{{__('Form')}}</a></li>
-                        @if ($task->processRequest->status === 'ACTIVE')
-                        @can('editData', $task->processRequest->process)
-                        <li class="nav-item"><a id="summary-tab" data-toggle="tab" href="#tab-data" role="tab" aria-controls="tab-data" aria-selected="false" class="nav-link">{{__('Data')}}</a></li>
+                    @if ($task->processRequest->status === 'ACTIVE')
+                        @can('editData', $task->processRequest)
+                            <ul id="tabHeader" role="tablist" class="nav nav-tabs">
+                                <li class="nav-item"><a id="pending-tab" data-toggle="tab" href="#tab-form" role="tab" aria-controls="tab-form" aria-selected="true" class="nav-link active">{{__('Form')}}</a></li>
+                                <li class="nav-item"><a id="summary-tab" data-toggle="tab" href="#tab-data" role="tab" aria-controls="tab-data" aria-selected="false" class="nav-link">{{__('Data')}}</a></li>
+                            </ul>
                         @endcan
-                        @endif
-                    </ul>
+                    @endif
                     <div id="tabContent" class="tab-content">
                         <div id="tab-form" role="tabpanel" aria-labelledby="tab-form" class="tab-pane active show">
                             @if ($task->getScreen() && ($task->advanceStatus==='open' || $task->advanceStatus==='overdue'))
@@ -57,7 +57,7 @@
                             @endif
                         </div>
                         @if ($task->processRequest->status === 'ACTIVE')
-                        @can('editData', $task->processRequest->process)
+                        @can('editData', $task->processRequest)
                         <div id="tab-data" role="tabpanel" aria-labelledby="tab-data" class="tab-pane">
                             @include('tasks.editdata')
                         </div>


### PR DESCRIPTION
Closes #1340. This ticket:

- Adds new global "edit request data" and "edit task data" permissions that can be assigned either to groups or users.
- Adds these permissions to the permissions UI.
- Enforces these permissions in the frontend and via the API.
- Includes unit testing to ensure these permissions are respected.

![screen shot 2019-02-12 at 11 30 27 am](https://user-images.githubusercontent.com/867714/52662682-b1e65300-2eb9-11e9-8210-d492475ab058.png)
