### PR TITLE
New default group seeders

### DIFF
--- a/ProcessMaker/Console/Commands/Install.php
+++ b/ProcessMaker/Console/Commands/Install.php
@@ -122,9 +122,12 @@ class Install extends Command
 
         // Set it as our url in our config
         config(['app.url' => $this->env['APP_URL']]);
+        
+        // Confirm whether the user would like to seed default groups
+        $seedDefaultGroups = $this->confirm(__('Would you like default user groups to be set up?'), true);
 
         //Confirm the user would like to setup their email
-        if ($this->confirm('Would you like to setup email options?')) {
+        if ($this->confirm(__('Would you like to setup email options?'))) {
             //Fetch from name & email from the user
             $this->fetchEmailFromInfo();
             
@@ -153,6 +156,13 @@ class Install extends Command
         $this->call('migrate:fresh', [
             '--seed' => true,
         ]);
+        
+        // Seed default user groups if desired
+        if ($seedDefaultGroups) {
+            $this->call('db:seed', [
+                '--class' => 'DefaultGroupSeeder',
+            ]);        
+        }
 
         // Generate passport secure keys and personal token oauth client
         $this->call('passport:install', [

--- a/ProcessMaker/Models/Permission.php
+++ b/ProcessMaker/Models/Permission.php
@@ -73,7 +73,11 @@ class Permission extends Model
     static public function byName($name)
     {
         try {
-            return self::where('name', $name)->firstOrFail();
+            if (is_array($name)) {
+                return self::whereIn('name', $name)->get();                
+            } else {
+                return self::where('name', $name)->firstOrFail();
+            }
         } catch(ModelNotFoundException $e) {
             throw new ModelNotFoundException($name . " permission does not exist");
         }

--- a/database/seeds/DefaultGroupSeeder.php
+++ b/database/seeds/DefaultGroupSeeder.php
@@ -1,0 +1,100 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+use ProcessMaker\Models\Group;
+use ProcessMaker\Models\Permission;
+
+class DefaultGroupSeeder extends Seeder
+{
+    public $defaults = [];
+    
+    public function setDefaults()
+    {
+        $this->defaults[] = [
+            'name' => __('Requesters'),
+            'description' => __('Users can view and start new requests.'),
+            'permissions' => [
+                'view-all_requests',
+                'view-users',
+                'view-groups',
+                'view-comments',
+                'create-comments',
+                'edit-comments',
+            ],
+        ];
+        
+        $this->defaults[] = [
+            'name' => __('Process Designers'),
+            'description' => __('Users can design processes.'),
+            'permissions' => [
+                'view-all_requests',
+                'view-processes',
+                'create-processes',
+                'edit-processes',
+                'archive-processes',
+                'view-categories',
+                'create-categories',
+                'edit-categories',
+                'delete-categories',
+                'view-screens',
+                'create-screens',
+                'edit-screens',
+                'delete-screens',
+                'view-scripts',
+                'create-scripts',
+                'edit-scripts',
+                'delete-scripts',
+                'view-environment_variables',
+                'view-users',
+                'view-groups',
+            ],
+        ];
+        
+        $this->defaults[] = [
+            'name' => __('Administrators'),
+            'description' => __('Users can administrate users, groups, and auth clients.'),
+            'permissions' => [
+                'view-users',
+                'create-users',
+                'edit-users',
+                'delete-users',
+                'view-groups',
+                'create-groups',
+                'edit-groups',
+                'delete-groups',
+                'view-auth_clients',
+                'create-auth_clients',
+                'edit-auth_clients',
+                'delete-auth_clients',
+                'delete-comments'
+            ],
+        ];    
+    }
+
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $this->setDefaults();
+                
+        foreach ($this->defaults as $defaultGroup) {
+            // Create the group
+            $createdGroup = factory(Group::class)->create([
+                'name' => $defaultGroup['name'],
+                'description' => $defaultGroup['description'],
+                'status' => 'ACTIVE'
+            ]);
+
+            //Retrieve permission IDs
+            $permissions = Permission::byName($defaultGroup['permissions'])->pluck('id');
+
+            //Attach permissions to this group
+            $createdGroup->permissions()->attach($permissions);
+        }
+
+    }
+}

--- a/database/seeds/PermissionSeeder.php
+++ b/database/seeds/PermissionSeeder.php
@@ -67,18 +67,6 @@ class PermissionSeeder extends Seeder
     public function run($seedUser = null)
     {
         if (Permission::count() === 0) {
-            $group = factory(Group::class)->create([
-                'name' => 'All Permissions',
-            ]);
-
-            if ($user = User::first()) {
-                factory(GroupMember::class)->create([
-                    'group_id' => $group->id,
-                    'member_type' => User::class,
-                    'member_id' => $user->id,
-                ]);
-            }
-
             foreach ($this->permissions as $permissionString) {
                 $permission = factory(Permission::class)->create([
                     'title' => ucwords(preg_replace('/(\-|_)/', ' ',
@@ -93,9 +81,6 @@ class PermissionSeeder extends Seeder
         if ($seedUser) {
             $seedUser->permissions()->attach($permissions);
             $seedUser->save();
-        } else {
-            $group->permissions()->attach($permissions);
-            $group->save();
         }
     }
 }

--- a/database/seeds/UserSeeder.php
+++ b/database/seeds/UserSeeder.php
@@ -20,11 +20,6 @@ class UserSeeder extends Seeder
         if (User::count() !== 0) {
             return;
         }
-        //Create default All Users group
-        $group_id = factory(Group::class)->create([
-                'name' => 'Users',
-                'status' => 'ACTIVE'
-            ])->id;
 
         //Create admin user
         $user = factory(User::class)->create([
@@ -36,13 +31,6 @@ class UserSeeder extends Seeder
             'datetime_format' => null,
             'status' => 'ACTIVE',
             'is_administrator' => true,
-        ]);
-
-
-        factory(GroupMember::class)->create([
-            'member_id' => $user->id,
-            'member_type' => User::class,
-            'group_id' => $group_id,
         ]);
 
         // Create personal access token

--- a/tests/Feature/Api/PermissionsTest.php
+++ b/tests/Feature/Api/PermissionsTest.php
@@ -34,6 +34,22 @@ class PermissionsTest extends TestCase
 
     public function testApiPermissions()
     {
+        $group = factory(Group::class)->create([
+            'name' => 'All Permissions',
+        ]);
+        $permissions = Permission::all()->pluck('id');
+        $group->permissions()->attach($permissions);
+        $group->save();
+        
+        factory(GroupMember::class)->create([
+            'group_id' => $group->id,
+            'member_type' => User::class,
+            'member_id' => $this->user->id,
+        ]);
+        
+        $this->user->refresh();
+        $this->flushSession();        
+        
         $process = factory(Process::class)->create([
             'user_id' => $this->user->id,
             'status' => 'ACTIVE',


### PR DESCRIPTION
Closes #1373. Adds seeding for the below default groups if called for during `bpm:install`.
- Requesters
- Process Designers
- Administrators

Removes the following groups which were previously created by default:
- Users
- All Permissions

_Installer with new question_
<img width="639" alt="screen shot 2019-02-19 at 2 25 50 pm" src="https://user-images.githubusercontent.com/867714/53053592-add8a900-3456-11e9-8138-75aa8c634c85.png">  

_New groups listed on the groups admin screen_
<img width="597" alt="screen shot 2019-02-19 at 3 02 30 pm" src="https://user-images.githubusercontent.com/867714/53053835-656dbb00-3457-11e9-9504-f2373e7a10e2.png">