### PR TITLE
Permissions typo fix

### DIFF
--- a/resources/views/admin/groups/edit.blade.php
+++ b/resources/views/admin/groups/edit.blade.php
@@ -79,7 +79,7 @@
                     <div class="tab-pane fade" id="nav-permissions" role="tabpanel" aria-labelledby="nav-permissions">
                         <div class="card">
                             <div class="card-body">
-                                <label class="mb-3"><input type="checkbox" v-model="selectAll" @click="select" :disabled="formData.is_administrator">  {{__('Assign all permisssions to this group')}} </label>
+                                <label class="mb-3"><input type="checkbox" v-model="selectAll" @click="select" :disabled="formData.is_administrator">  {{__('Assign all permissions to this group')}} </label>
                                 @include('admin.shared.permissions')
                                 <div class="text-right mt-2">
                                     {!! Form::button('Cancel', ['class'=>'btn btn-outline-secondary', '@click' => 'onClose'])!!}

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -256,7 +256,7 @@
                     <div class="tab-pane fade" id="nav-profile" role="tabpanel" aria-labelledby="nav-profile-tab">
                         <div class="accordion" id="accordionExample">
                             <label><input type="checkbox" v-model="formData.is_administrator" @input="adminHasChanged = true">  {{__('Make this user a Super Admin')}} </label>
-                            <label class="mb-3"><input type="checkbox" v-model="selectAll" @click="select" :disabled="formData.is_administrator">  {{__('Assign all permisssions to this user')}} </label>
+                            <label class="mb-3"><input type="checkbox" v-model="selectAll" @click="select" :disabled="formData.is_administrator">  {{__('Assign all permissions to this user')}} </label>
                             @include('admin.shared.permissions')
                         </div>
                         <div class="text-right mt-2">


### PR DESCRIPTION
Fixes "permisssions" typo on two pages. Closes #1396.