### PR TITLE
Timer Start Events with End Date aren't handled properly #1439

### DIFF
--- a/ProcessMaker/Managers/TaskSchedulerManager.php
+++ b/ProcessMaker/Managers/TaskSchedulerManager.php
@@ -406,7 +406,7 @@ class TaskSchedulerManager implements JobManagerInterface, EventBusInterface
                 $result = $parts['firstDate'];
                 break;
             case 'TimeCycle':
-                $result = $parts['repetitions']. '/'. $parts['firstDate'] . '/' . $parts['interval'];
+                $result = $parts['repetitions']. '/'. $parts['firstDate'] . '/' . $parts['interval']. '/' . $parts['endDate'];
                 break;
             case 'TimeDuration':
                 $result = $parts['interval'];


### PR DESCRIPTION
Fixes #1439 

Now the timer data stored in table scheduled_ tasks includes the end date

{"type":"TimeCycle","interval":"R9\/2019-02-26T19:30:00Z\/P1W\/2029-02-27T14:38:29Z","element_id":"node_2"}

