### PR TITLE
Intermediate Timer Events aren't updating correctly the last time of execution #1447

### DIFF
--- a/ProcessMaker/Managers/TaskSchedulerManager.php
+++ b/ProcessMaker/Managers/TaskSchedulerManager.php
@@ -198,10 +198,12 @@ class TaskSchedulerManager implements JobManagerInterface, EventBusInterface
                            $task->save();
                            break;
                        case 'INTERMEDIATE_TIMER_EVENT':
-                           $this->executeIntermediateTimerEvent($task, $config);
+                           $executed = $this->executeIntermediateTimerEvent($task, $config);
                            $today = (new \DateTime())->setTimezone(new DateTimeZone('UTC'));
                            $task->last_execution = $today->format('Y-m-d H:i:s');
-                           $task->save();
+                           if ($executed) {
+                               $task->save();
+                           }
                            break;
                    }
                })->when(function() use($nextDate, $today) {
@@ -259,9 +261,13 @@ class TaskSchedulerManager implements JobManagerInterface, EventBusInterface
 
         $catch = $request->tokens()->where('element_id', $config->element_id)->first();
 
+        $executed = false;
         if ($catch) {
             WorkflowManager::completeCatchEvent($process, $request, $catch, []);
+            $executed = true;
         }
+
+        return $executed;
    }
 
    public function nextDate($currentDate, $intervalConfig, $firstOccurrenceDate = null)

--- a/ProcessMaker/Models/ProcessRequest.php
+++ b/ProcessMaker/Models/ProcessRequest.php
@@ -130,16 +130,16 @@ class ProcessRequest extends Model implements ExecutionInstanceInterface, HasMed
         $this->bootElement([]);
     }
 
-    protected static function boot()
-    {
-        parent::boot();
-
-        static::saved(function ($model) {
-            $manager = new TaskSchedulerManager();
-            $manager->registerIntermediateTimerEvents($model);
-        });
-
-    }
+//    protected static function boot()
+//    {
+//        parent::boot();
+//
+//        static::created(function ($model) {
+//            $manager = new TaskSchedulerManager();
+//            $manager->registerIntermediateTimerEvents($model);
+//        });
+//
+//    }
 
     /**
      * Validation rules.


### PR DESCRIPTION
Fixes #1447 
 The last execution date is updated just when the intermediate event runs.