### PR TITLE
Fix installer script when bad db info is entered

### DIFF
--- a/ProcessMaker/Console/Commands/Install.php
+++ b/ProcessMaker/Console/Commands/Install.php
@@ -326,7 +326,6 @@ class Install extends Command
         try {
             $pdo = DB::connection('install')->getPdo();
         } catch(Exception $e) {
-            dd($e);
             $this->error(__("Failed to connect to MySQL database. Check your credentials and try again. Note, the database must also exist."));
             return false;
         }


### PR DESCRIPTION
Fixes #1362 

There was a dd() command in there that was breaking the interactive input. Error is correctly handled when it's removed