### PR TITLE
The permissions tab lost established styles

### DIFF
--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -275,7 +275,7 @@
                             </div>
                         </div>
                         <div class="tab-pane fade" id="nav-profile" role="tabpanel" aria-labelledby="nav-profile-tab">
-                            <div class="accordion" id="accordionExample">
+                            <div class="accordion card card-body" id="accordionPermissions">
                                 <label>
                                     <input type="checkbox" v-model="formData.is_administrator"
                                            @input="adminHasChanged = true">


### PR DESCRIPTION
Fixes #1463 

- Add style card to tab permissions.

![image](https://user-images.githubusercontent.com/1747025/53662409-331f4300-3c39-11e9-8fe9-05d3d7918066.png)
