### PR TITLE
The second execution an intermediate timer event generates an error #1500

### DIFF
--- a/tests/Feature/Api/IntermediateTimerEventTest.php
+++ b/tests/Feature/Api/IntermediateTimerEventTest.php
@@ -91,6 +91,9 @@ class IntermediateTimerEventTest extends TestCase
         $task->type= 'INTERMEDIATE_TIMER_EVENT';
         $manager->executeIntermediateTimerEvent($task, json_decode($task->configuration));
 
+        $task->configuration = '{"type":"TimeCycle","interval":"R4\/2019-02-13T13:08:00Z\/PT1M", "element_id" : "_5"}';
+        $manager->executeIntermediateTimerEvent($task, json_decode($task->configuration));
+
         // If no exception has been thrown, this assertion will be executed
         $this->assertTrue(true);
     }

--- a/tests/Feature/Api/IntermediateTimerEventTest.php
+++ b/tests/Feature/Api/IntermediateTimerEventTest.php
@@ -91,6 +91,7 @@ class IntermediateTimerEventTest extends TestCase
         $task->type= 'INTERMEDIATE_TIMER_EVENT';
         $manager->executeIntermediateTimerEvent($task, json_decode($task->configuration));
 
+        // executing a second time
         $task->configuration = '{"type":"TimeCycle","interval":"R4\/2019-02-13T13:08:00Z\/PT1M", "element_id" : "_5"}';
         $manager->executeIntermediateTimerEvent($task, json_decode($task->configuration));
 


### PR DESCRIPTION
Fixes #1500 

- One test  was modified to replicate the problem
- The problem was caused because the manager tried to run the catch event even if it was closed. The issue was fixed.
- Some code clean and formatting was done.
