### PR TITLE
Including run_as_user_id in PUT request

### DIFF
--- a/resources/js/processes/scripts/components/ScriptEditor.vue
+++ b/resources/js/processes/scripts/components/ScriptEditor.vue
@@ -110,7 +110,8 @@
                     .put("scripts/" + this.script.id, {
                         code: this.code,
                         title: this.script.title,
-                        language: this.script.language
+                        language: this.script.language,
+                        run_as_user_id: this.script.run_as_user_id
                     })
                     .then(response => {
                         ProcessMaker.alert("The script was saved.", "success");


### PR DESCRIPTION
Fixes #1528 where a field was required but was not being passed to the API upon saving in the script builder.