### PR TITLE
return more than 10 scripts in the modeler

### DIFF
--- a/resources/js/processes/modeler/components/inspector/ScriptSelect.vue
+++ b/resources/js/processes/modeler/components/inspector/ScriptSelect.vue
@@ -55,8 +55,11 @@ export default {
         },
         load() {
             this.loading = true;
+            let params = Object.assign({ per_page: 10000 })
             ProcessMaker.apiClient
-                .get("/scripts")
+                .get("/scripts",{
+                    params: params
+                } )
                 .then(response => {
                     this.screens = response.data.data;
                     this.loading = false;


### PR DESCRIPTION
closes #1355 

When selecting a script there are now more than just the first ten being returned.

![Screen Shot 2019-03-18 at 9 58 28 AM](https://user-images.githubusercontent.com/29641725/54548489-45052380-4965-11e9-897b-6d94f2005f73.png)
