### PR TITLE
Allow packages to add user & group permissions

### DIFF
--- a/ProcessMaker/Http/Controllers/Admin/GroupController.php
+++ b/ProcessMaker/Http/Controllers/Admin/GroupController.php
@@ -29,7 +29,13 @@ class GroupController extends Controller
     {
         $permissionNames = $group->permissions()->pluck('name')->toArray();
         $all_permissions = Permission::all();
-        return view('admin.groups.edit', compact('group', 'permissionNames', 'all_permissions'));
+        $permissionGroups = $all_permissions->sortBy('title')->groupBy('group')->sortKeys();
+        return view('admin.groups.edit', compact(
+            'group',
+            'permissionNames',
+            'all_permissions',
+            'permissionGroups'
+        ));
     }
 
     public function show(Group $group)

--- a/ProcessMaker/Http/Controllers/Admin/UserController.php
+++ b/ProcessMaker/Http/Controllers/Admin/UserController.php
@@ -37,6 +37,7 @@ class UserController extends Controller
         $groups = $this->getAllGroups();
         $all_permissions = Permission::all();
         $permissionNames = $user->permissions()->pluck('name')->toArray();
+        $permissionGroups = $all_permissions->sortBy('title')->groupBy('group')->sortKeys();
 
         $currentUser = $user;
         $states = JsonData::states();
@@ -56,9 +57,18 @@ class UserController extends Controller
             }
         );
 
-        return view('admin.users.edit', compact(['user', 'groups', 'all_permissions','permissionNames',
-             'states', 'timezones', 'countries', 'datetimeFormats',
-            ]));
+        return view('admin.users.edit', compact([
+                'user',
+                'groups',
+                'all_permissions',
+                'permissionNames',
+                'permissionGroups',
+                'states',
+                'timezones',
+                'countries',
+                'datetimeFormats',
+            ])
+        );
     }
 
     /**

--- a/ProcessMaker/Http/Controllers/Admin/UserController.php
+++ b/ProcessMaker/Http/Controllers/Admin/UserController.php
@@ -57,18 +57,17 @@ class UserController extends Controller
             }
         );
 
-        return view('admin.users.edit', compact([
-                'user',
-                'groups',
-                'all_permissions',
-                'permissionNames',
-                'permissionGroups',
-                'states',
-                'timezones',
-                'countries',
-                'datetimeFormats',
-            ])
-        );
+        return view('admin.users.edit', compact(
+            'user',
+            'groups',
+            'all_permissions',
+            'permissionNames',
+            'permissionGroups',
+            'states',
+            'timezones',
+            'countries',
+            'datetimeFormats'
+        ));
     }
 
     /**

--- a/ProcessMaker/Models/Permission.php
+++ b/ProcessMaker/Models/Permission.php
@@ -11,6 +11,7 @@ class Permission extends Model
     protected $fillable = [
         'title',
         'name',
+        'group',
     ];
     
     public function getResourceTitleAttribute()

--- a/ProcessMaker/Models/Permission.php
+++ b/ProcessMaker/Models/Permission.php
@@ -29,13 +29,21 @@ class Permission extends Model
             return $matches[2];
         }
     }
+    
+    public function getActionAttribute()
+    {
+        $match = preg_match("/(.+)-(.+)/", $this->name, $matches);
+        if ($match === 1) {
+            return $matches[1];
+        }
+    }
 
     static public function resourceTitleList()
     {
         //Grab all of our permissions
         $all = self::all();
         
-        $grouped = $all->groupBy('resource_title');
+        $grouped = $all->groupBy('resource_title')->sort();
         return $grouped;
     }
 

--- a/database/factories/PermissionFactory.php
+++ b/database/factories/PermissionFactory.php
@@ -6,5 +6,6 @@ $factory->define(ProcessMaker\Models\Permission::class, function (Faker $faker) 
     return [
         'title' => $faker->sentence(2),
         'name' => $faker->sentence(2),
+        'group' => $faker->word(),
     ];
 });

--- a/database/migrations/2019_03_20_214047_add_group_field_to_permissions_table.php
+++ b/database/migrations/2019_03_20_214047_add_group_field_to_permissions_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddGroupFieldToPermissionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('permissions', function (Blueprint $table) {
+            $table->string('group')->after('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('permissions', function (Blueprint $table) {
+            $table->dropColumn('group');
+        });
+    }
+}

--- a/database/seeds/PermissionSeeder.php
+++ b/database/seeds/PermissionSeeder.php
@@ -64,19 +64,19 @@ class PermissionSeeder extends Seeder
             'edit-request_data',
             'edit-task_data',
         ],
-        'Files' => [
+        'Files (API)' => [
             'create-files',
             'view-files',
             'edit-files',
             'delete-files',
         ],
-        'Notifications' => [
+        'Notifications (API)' => [
             'create-notifications',
             'view-notifications',
             'edit-notifications',
             'delete-notifications',
         ],
-        'Task Assignments' => [
+        'Task Assignments (API)' => [
             'create-task_assignments',
             'view-task_assignments',
             'edit-task_assignments',

--- a/database/seeds/PermissionSeeder.php
+++ b/database/seeds/PermissionSeeder.php
@@ -8,71 +8,100 @@ use ProcessMaker\Models\Permission;
 
 class PermissionSeeder extends Seeder
 {
-    private $permissions = [
-        'archive-processes',
-        'create-categories',
-        'create-comments',
-        'create-environment_variables',
-        'create-groups',
-        'create-processes',
-        'create-screens',
-        'create-scripts',
-        'create-users',
-        'delete-categories',
-        'delete-comments',
-        'delete-environment_variables',
-        'delete-groups',
-        'delete-screens',
-        'delete-scripts',
-        'delete-users',
-        'edit-categories',
-        'edit-comments',
-        'edit-environment_variables',
-        'edit-groups',
-        'edit-processes',
-        'edit-screens',
-        'edit-scripts',
-        'edit-users',
-        'export-processes',
-        'import-processes',
-        'view-all_requests',
-        'view-categories',
-        'view-comments',
-        'view-environment_variables',
-        'view-groups',
-        'view-processes',
-        'view-screens',
-        'view-scripts',
-        'view-users',
-        'create-files',
-        'view-files',
-        'edit-files',
-        'delete-files',
-        'create-notifications',
-        'view-notifications',
-        'edit-notifications',
-        'delete-notifications',
-        'create-task_assignments',
-        'view-task_assignments',
-        'edit-task_assignments',
-        'delete-task_assignments',
-        'create-auth_clients',
-        'view-auth_clients',
-        'edit-auth_clients',
-        'delete-auth_clients',
-        'edit-request_data',
-        'edit-task_data',
+    private $permissionGroups = [
+        'Processes' => [
+            'archive-processes',
+            'create-processes',
+            'edit-processes',
+            'export-processes',
+            'import-processes',
+            'view-processes',
+        ],
+        'Categories' => [
+            'create-categories',
+            'delete-categories',
+            'edit-categories',
+            'view-categories',
+        ],
+        'Comments' => [
+            'create-comments',
+            'delete-comments',
+            'edit-comments',
+            'view-comments',
+        ],
+        'Environment Variables' => [
+            'create-environment_variables',
+            'delete-environment_variables',
+            'edit-environment_variables',
+            'view-environment_variables',
+        ],
+        'Groups' => [
+            'create-groups',
+            'delete-groups',
+            'edit-groups',
+            'view-groups',
+        ],
+        'Screens' => [
+            'create-screens',
+            'delete-screens',
+            'edit-screens',
+            'view-screens',
+        ],
+        'Scripts' => [
+            'create-scripts',
+            'delete-scripts',
+            'edit-scripts',
+            'view-scripts',
+        ],
+        'Users' => [
+            'create-users',
+            'delete-users',
+            'edit-users',
+            'view-users',
+        ],
+        'Requests' => [
+            'view-all_requests',
+            'edit-request_data',
+            'edit-task_data',
+        ],
+        'Files' => [
+            'create-files',
+            'view-files',
+            'edit-files',
+            'delete-files',
+        ],
+        'Notifications' => [
+            'create-notifications',
+            'view-notifications',
+            'edit-notifications',
+            'delete-notifications',
+        ],
+        'Task Assignments' => [
+            'create-task_assignments',
+            'view-task_assignments',
+            'edit-task_assignments',
+            'delete-task_assignments',
+        ],
+        'Auth Clients' => [
+            'create-auth_clients',
+            'view-auth_clients',
+            'edit-auth_clients',
+            'delete-auth_clients',
+        ],
     ];
-    
+
     public function run($seedUser = null)
     {
         if (Permission::count() === 0) {
-            foreach ($this->permissions as $permissionString) {
-                $permission = factory(Permission::class)->create([
-                    'title' => ucwords(preg_replace('/(\-|_)/', ' ',
-                            $permissionString)),
-                    'name' => $permissionString,
-                ]);
+            foreach ($this->permissionGroups as $groupName => $permissions) {
+                foreach ($permissions as $permissionString) {
+                    $permission = factory(Permission::class)->create([
+                        'title' => ucwords(preg_replace('/(\-|_)/', ' ',
+                                $permissionString)),
+                        'name' => $permissionString,
+                        'group' => $groupName,
+                    ]);
+                }
             }
         }
 

--- a/resources/views/admin/shared/permissions.blade.php
+++ b/resources/views/admin/shared/permissions.blade.php
@@ -1,225 +1,28 @@
-<div class="card">
-    <div class="card-header">
-        <div class="mb-0">
-            <button class="btn btn-link collapsed d-flex w-100 justify-content-between" type="button" data-toggle="collapse" data-target="#requests">
-             <div>{{__('Requests')}}</div> <div><i class="fas fa-chevron-circle-down arrow-open mr-2"></i> <i class="fas fa-chevron-circle-left arrow-closed mr-2"></i> </div>  
-            </button>
+@foreach ($permissionGroups as $groupName => $permissions)
+    <div class="card">
+        <div class="card-header">
+            <div class="mb-0">
+                <button class="btn btn-link collapsed d-flex w-100 justify-content-between" type="button" data-toggle="collapse" data-target="#{{ str_slug($groupName) }}">
+                 <div>{{__($groupName)}}</div> <div><i class="fas fa-chevron-circle-down arrow-open mr-2"></i> <i class="fas fa-chevron-circle-left arrow-closed mr-2"></i> </div>  
+                </button>
+            </div>
+        </div>
+        <div id="{{ str_slug($groupName) }}" class="collapse" >
+            <div class="card-body">
+                @foreach ($permissions as $permission)
+                    <label><input type="checkbox"
+                                  :disabled="formData.is_administrator"
+                                  value="{{ $permission->name }}"
+                                  v-model="selectedPermissions"
+                                  @if ($permission->action == 'create')@@change="checkCreate('edit-{{ $permission->resource_name }}', $event)"@endif
+                                  @if ($permission->action == 'edit')@@change="checkEdit('create-{{ $permission->resource_name }}', $event)"@endif
+                            > {{__($permission->title)}}
+                    </label>
+                @endforeach
+            </div>
         </div>
     </div>
-    <div id="requests" class="collapse" >
-        <div class="card-body">
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="view-all_requests" v-model="selectedPermissions">   {{__('View All Requests')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="edit-request_data" v-model="selectedPermissions">   {{__('Edit Request Data')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="edit-task_data" v-model="selectedPermissions">   {{__('Edit Task Data')}}</label>
-        </div>
-    </div>
-</div>
-<div class="card">
-    <div class="card-header">
-        <div class="mb-0">
-            <button class="btn btn-link collapsed d-flex w-100 justify-content-between" type="button" data-toggle="collapse" data-target="#scripts">
-             <div>{{__('Scripts')}}</div> <div><i class="fas fa-chevron-circle-down arrow-open mr-2"></i> <i class="fas fa-chevron-circle-left arrow-closed mr-2"></i> </div>  
-            </button>
-        </div>
-    </div>
-    <div id="scripts" class="collapse" >
-        <div class="card-body">
-            <label><input type="checkbox" name="view-scripts" :disabled="formData.is_administrator" value="view-scripts" v-model="selectedPermissions">   {{__('View Scripts')}}</label>
-            <label><input type="checkbox" name="create-scripts" :disabled="formData.is_administrator" value="create-scripts" v-model="selectedPermissions" @change="checkCreate('edit-scripts', $event)">   {{__('Create Scripts')}}</label>
-            <label><input type="checkbox" name="edit-scripts" :disabled="formData.is_administrator" value="edit-scripts" v-model="selectedPermissions" @change="checkEdit('create-scripts', $event)">   {{__('Edit Scripts')}}</label>
-            <label><input type="checkbox" name="delete-scripts" :disabled="formData.is_administrator" value="delete-scripts" v-model="selectedPermissions">   {{__('Delete Scripts')}}</label>
-        </div>
-    </div>
-</div>
-<div class="card">
-    <div class="card-header">
-        <div class="mb-0">
-            <button class="btn btn-link collapsed d-flex w-100 justify-content-between" type="button" data-toggle="collapse" data-target="#categories">
-              <div>{{__('Categories')}}</div> <div><i class="fas fa-chevron-circle-down arrow-open mr-2"></i> <i class="fas fa-chevron-circle-left arrow-closed mr-2"></i> </div>
-            </button>
-        </div>
-    </div>
-    <div id="categories" class="collapse" >
-        <div class="card-body">
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="view-categories" v-model="selectedPermissions">   {{__('View Categories')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="create-categories" v-model="selectedPermissions" @change="checkCreate('edit-categories', $event)">   {{__('Create Categories')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="edit-categories" v-model="selectedPermissions" @change="checkEdit('create-categories', $event)">   {{__('Edit Categories')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="delete-categories" v-model="selectedPermissions">   {{__('Delete Categories')}}</label>
-        </div>
-    </div>
-</div>
-<div class="card">
-    <div class="card-header">
-        <div class="mb-0">
-            <button class="btn btn-link collapsed d-flex w-100 justify-content-between" type="button" data-toggle="collapse" data-target="#screens">
-             <div>{{__('Screens')}}</div> <div><i class="fas fa-chevron-circle-down arrow-open mr-2"></i> <i class="fas fa-chevron-circle-left arrow-closed mr-2"></i> </div> 
-            </button>
-        </div>
-    </div>
-    <div id="screens" class="collapse" >
-        <div class="card-body">
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="view-screens" v-model="selectedPermissions">   {{__('View Screens')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="create-screens" v-model="selectedPermissions" @change="checkCreate('edit-screens', $event)">   {{__('Create Screens')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="edit-screens" v-model="selectedPermissions" @change="checkEdit('create-screens', $event)">   {{__('Edit Screens')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="delete-screens" v-model="selectedPermissions">   {{__('Delete Screens')}}</label>
-        </div>
-    </div>
-</div>
-<div class="card">
-    <div class="card-header">
-        <div class="mb-0">
-            <button class="btn btn-link collapsed d-flex w-100 justify-content-between" type="button" data-toggle="collapse" data-target="#environment_variables">
-              <div>{{__('Environment Variables')}}</div> <div><i class="fas fa-chevron-circle-down arrow-open mr-2"></i> <i class="fas fa-chevron-circle-left arrow-closed mr-2"></i> </div> 
-            </button>
-        </div>
-    </div>
-    <div id="environment_variables" class="collapse" >
-        <div class="card-body">
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="view-environment_variables" v-model="selectedPermissions">   {{__('View Environment Variables')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="create-environment_variables" v-model="selectedPermissions" @change="checkCreate('edit-environment_variables', $event)">   {{__('Create Environment Variables')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="edit-environment_variables" v-model="selectedPermissions" @change="checkEdit('create-environment_variables', $event)">   {{__('Edit Environment Variables')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="delete-environment_variables" v-model="selectedPermissions">   {{__('Delete Environment Variables')}}</label>
-        </div>
-    </div>
-</div>
-<div class="card">
-    <div class="card-header">
-        <div class="mb-0">
-            <button class="btn btn-link collapsed d-flex w-100 justify-content-between" type="button" data-toggle="collapse" data-target="#users">
-              <div>{{__('Users')}}</div> <div><i class="fas fa-chevron-circle-down arrow-open mr-2"></i> <i class="fas fa-chevron-circle-left arrow-closed mr-2"></i> </div> 
-            </button>
-        </div>
-    </div>
-    <div id="users" class="collapse" >
-        <div class="card-body">
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="view-users" v-model="selectedPermissions">   {{__('View Users')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="create-users" v-model="selectedPermissions" @change="checkCreate('edit-users', $event)">   {{__('Create Users')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="edit-users" v-model="selectedPermissions" @change="checkEdit('create-users', $event)">   {{__('Edit Users')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="delete-users" v-model="selectedPermissions">   {{__('Delete Users')}}</label>
-        </div>
-    </div>
-</div>
-<div class="card">
-    <div class="card-header">
-        <div class="mb-0">
-            <button class="btn btn-link collapsed d-flex w-100 justify-content-between" type="button" data-toggle="collapse" data-target="#groups">
-              <div>{{__('Groups')}}</div><div><i class="fas fa-chevron-circle-down arrow-open mr-2"></i> <i class="fas fa-chevron-circle-left arrow-closed mr-2"></i> </div> 
-            </button>
-        </div>
-    </div>
-    <div id="groups" class="collapse" >
-        <div class="card-body">
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="view-groups" v-model="selectedPermissions">   {{__('View Groups')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="create-groups" v-model="selectedPermissions" @change="checkCreate('edit-groups', $event)">   {{__('Create Groups')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="edit-groups" v-model="selectedPermissions" @change="checkEdit('create-groups', $event)">   {{__('Edit Groups')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="delete-groups" v-model="selectedPermissions">   {{__('Delete Groups')}}</label>
-        </div>
-    </div>
-</div>
-<div class="card">
-    <div class="card-header">
-        <div class="mb-0">
-            <button class="btn btn-link collapsed d-flex w-100 justify-content-between" type="button" data-toggle="collapse" data-target="#processes">
-              <div>{{__('Processes')}}</div>  <div><i class="fas fa-chevron-circle-down arrow-open mr-2"></i> <i class="fas fa-chevron-circle-left arrow-closed mr-2"></i> </div>
-            </button>
-        </div>
-    </div>
-    <div id="processes" class="collapse" >
-        <div class="card-body">
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="view-processes" v-model="selectedPermissions">   {{__('View Processes')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="create-processes" v-model="selectedPermissions" @change="checkCreate('edit-processes', $event)">   {{__('Create Processes')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="edit-processes" v-model="selectedPermissions" @change="checkEdit('create-processes', $event)">   {{__('Edit Processes')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="archive-processes" v-model="selectedPermissions">   {{__('Archive Processes')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="import-processes" v-model="selectedPermissions">   {{__('Import Processes')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="export-processes" v-model="selectedPermissions">   {{__('Export Processes')}}</label>
-        </div>
-    </div>
-</div>
-<div class="card">
-    <div class="card-header">
-        <div class="mb-0">
-            <button class="btn btn-link collapsed d-flex w-100 justify-content-between" type="button" data-toggle="collapse" data-target="#comments">
-              <div>{{__('Comments')}}</div> <div><i class="fas fa-chevron-circle-down arrow-open mr-2"></i> <i class="fas fa-chevron-circle-left arrow-closed mr-2"></i> </div> 
-            </button>
-        </div>
-    </div>
-    <div id="comments" class="collapse" >
-        <div class="card-body">
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="view-comments" v-model="selectedPermissions">   {{__('View Comments')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="create-comments" v-model="selectedPermissions" @change="checkCreate('edit-comments', $event)">   {{__('Create Comments')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="edit-comments" v-model="selectedPermissions" @change="checkEdit('create-comments', $event)">   {{__('Edit Comments')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="delete-comments" v-model="selectedPermissions">   {{__('Delete Comments')}}</label>
-        </div>
-    </div>
-</div>
-<div class="card">
-    <div class="card-header">
-        <div class="mb-0">
-            <button class="btn btn-link collapsed d-flex w-100 justify-content-between" type="button" data-toggle="collapse" data-target="#auth_clients">
-             <div>{{__('Auth-Clients')}}</div> <div><i class="fas fa-chevron-circle-down arrow-open mr-2"></i> <i class="fas fa-chevron-circle-left arrow-closed mr-2"></i> </div> 
-            </button>
-        </div>
-    </div>
-    <div id="auth_clients" class="collapse" >
-        <div class="card-body">
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="view-auth_clients" v-model="selectedPermissions">   {{__('View Auth-Clients')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="create-auth_clients" v-model="selectedPermissions" @change="checkCreate('edit-auth_clients', $event)">   {{__('Create Auth-Clients')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="edit-auth_clients" v-model="selectedPermissions" @change="checkEdit('create-auth_clients', $event)">   {{__('Edit Auth-Clients')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="delete-auth_clients" v-model="selectedPermissions">   {{__('Delete Auth-Clients')}}</label>
-        </div>
-    </div>
-</div>
-<div class="card">
-    <div class="card-header">
-        <div class="mb-0">
-            <button class="btn btn-link collapsed d-flex w-100 justify-content-between" type="button" data-toggle="collapse" data-target="#files">
-               <div>{{__('Files (API)')}}</div> <div><i class="fas fa-chevron-circle-down arrow-open mr-2"></i> <i class="fas fa-chevron-circle-left arrow-closed mr-2"></i> </div>
-            </button>
-        </div>
-    </div>
-    <div id="files" class="collapse" >
-        <div class="card-body">
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="view-files" v-model="selectedPermissions">   {{__('View Files')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="create-files" v-model="selectedPermissions">   {{__('Create Files')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="edit-files" v-model="selectedPermissions">   {{__('Edit Files')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="delete-files" v-model="selectedPermissions">   {{__('Delete Files')}}</label>
-        </div>
-    </div>
-</div>
-<div class="card">
-    <div class="card-header">
-        <div class="mb-0">
-            <button class="btn btn-link collapsed d-flex w-100 justify-content-between" type="button" data-toggle="collapse" data-target="#notifications">
-             <div>{{__('Notifications (API)')}} </div> <div><i class="fas fa-chevron-circle-down arrow-open mr-2"></i> <i class="fas fa-chevron-circle-left arrow-closed mr-2"></i> </div> 
-            </button>
-        </div>
-    </div>
-    <div id="notifications" class="collapse" >
-        <div class="card-body">
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="view-notifications" v-model="selectedPermissions">   {{__('View Notifications')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="create-notifications" v-model="selectedPermissions">   {{__('Create Notifications')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="edit-notifications" v-model="selectedPermissions">   {{__('Edit Notifications')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="delete-notifications" v-model="selectedPermissions">   {{__('Delete Notifications')}}</label>
-        </div>
-    </div>
-</div>
-<div class="card">
-    <div class="card-header">
-        <div class="mb-0">
-            <button class="btn btn-link collapsed d-flex w-100 justify-content-between" type="button" data-toggle="collapse" data-target="#task_assignments">
-              <div>{{__('Task Assignments (API)')}}</div> <div><i class="fas fa-chevron-circle-down arrow-open mr-2"></i> <i class="fas fa-chevron-circle-left arrow-closed mr-2"></i> </div> 
-            </button>
-        </div>
-    </div>
-    <div id="task_assignments" class="collapse" >
-        <div class="card-body">
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="view-task_assignments" v-model="selectedPermissions">   {{__('View Task Assignments')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="create-task_assignments" v-model="selectedPermissions">   {{__('Create Task Assignments')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="edit-task_assignments" v-model="selectedPermissions">   {{__('Edit Task Assignments')}}</label>
-            <label><input type="checkbox" :disabled="formData.is_administrator" value="delete-task_assignments" v-model="selectedPermissions">   {{__('Delete Task Assignments')}}</label>
-        </div>
-    </div>
-</div>
+@endforeach
 
 @section('css')
     <style scoped>

--- a/tests/Feature/PermissionsTest.php
+++ b/tests/Feature/PermissionsTest.php
@@ -108,4 +108,19 @@ class PermissionsTest extends TestCase
         $response = $this->webCall('GET', $url);
         $response->assertStatus(200);
     }
+    
+    public function testCreatePermission()
+    {
+        $attributes = [
+            'name' => 'create-package_permissions',
+            'title' => 'Create Package Permissions',
+            'group' => 'Package Permissions',
+        ];
+
+        $this->assertDatabaseMissing('permissions', $attributes);
+        
+        factory(Permission::class)->create($attributes);
+
+        $this->assertDatabaseHas('permissions', $attributes);
+    }
 }


### PR DESCRIPTION
## Changes
- Adds testing to ensure created permissions are added to the database
- Adds a group field to the permissions table to allow UI categorization
- Permissions UI now pulls alphabetically from database permission groups and permissions; previously was hard-coded

## Notes
- PR 6 in pm4-package-collections relies on this functionality
- Permissions added by packages should follow the format **action-resource_name** (example: view-auth_clients)
- When testing, be sure to run `php artisan migrate:fresh --seed` to enable this functionality

## Screenshot
![Screen Shot 2019-03-20 at 3 45 14 PM](https://user-images.githubusercontent.com/867714/54724160-349ca680-4b27-11e9-89f2-578268339338.png)

Closes #1559.