### PR TITLE
Add stackable alerts with default timeout

### DIFF
--- a/resources/js/app-layout.js
+++ b/resources/js/app-layout.js
@@ -71,7 +71,7 @@ window.ProcessMaker.navbar = new Vue({
 
 // Set our own specific alert function at the ProcessMaker global object that could
 // potentially be overwritten by some custom theme support
-window.ProcessMaker.alert = function (msg, variant, showValue = 3) {
+window.ProcessMaker.alert = function (msg, variant, showValue = 60) {
     if (showValue === 0) {
         // Just show it indefinitely, no countdown
         showValue = true;

--- a/resources/js/app-layout.js
+++ b/resources/js/app-layout.js
@@ -48,9 +48,7 @@ window.ProcessMaker.navbar = new Vue({
     data() {
         return {
             messages: ProcessMaker.notifications,
-            alertShow: false,
-            alertText: "",
-            alertVariant: "",
+            alerts: [],
             confirmTitle: "",
             confirmMessage: "",
             confirmVariant: "",
@@ -78,9 +76,11 @@ window.ProcessMaker.alert = function (msg, variant, showValue = 3) {
         // Just show it indefinitely, no countdown
         showValue = true;
     }
-    ProcessMaker.navbar.alertText = msg;
-    ProcessMaker.navbar.alertShow = showValue;
-    ProcessMaker.navbar.alertVariant = String(variant);
+    ProcessMaker.navbar.alerts.push({
+        alertText: msg,
+        alertShow: showValue,
+        alertVariant: String(variant)
+    })
 };
 
 // Set out own specific confirm modal.

--- a/resources/js/app-layout.js
+++ b/resources/js/app-layout.js
@@ -73,9 +73,13 @@ window.ProcessMaker.navbar = new Vue({
 
 // Set our own specific alert function at the ProcessMaker global object that could
 // potentially be overwritten by some custom theme support
-window.ProcessMaker.alert = function (msg, variant) {
+window.ProcessMaker.alert = function (msg, variant, showValue = 3) {
+    if (showValue === 0) {
+        // Just show it indefinitely, no countdown
+        showValue = true;
+    }
     ProcessMaker.navbar.alertText = msg;
-    ProcessMaker.navbar.alertShow = true;
+    ProcessMaker.navbar.alertShow = showValue;
     ProcessMaker.navbar.alertVariant = String(variant);
 };
 

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -407,11 +407,16 @@ h1.page-title {
   margin-bottom: 6px;
 }
 
-#alertBox {
+.alert-wrapper {
   position: fixed;
+  top: 0.5em;
   left: 30%;
   right: 30%;
-  z-index: 50000;
+  z-index: 100;
+}
+
+.alertBox {
+  width: 100%
 }
 
 .avatar-circle-list {

--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -9,9 +9,12 @@
                             :variant="confirmVariant" :callback="confirmCallback"
                             @close="confirmShow=false">
         </confirmation-modal>
-        <b-alert class="d-none d-lg-block" :show="alertShow" id="alertBox" :variant="alertVariant" @dismissed="alertShow=0" dismissible fade>
-            @{{alertText}}
-        </b-alert>
+
+        <div v-if="alerts.length > 0" class="alert-wrapper">
+            <b-alert v-for="(item, index) in alerts" class="d-none d-lg-block alertBox" :show="item.alertShow" :variant="item.alertVariant" dismissible fade>
+                @{{item.alertText}}
+            </b-alert>
+        </div>
 
         <b-navbar-nav class="d-flex align-items-center">
             @foreach(Menu::get('topnav')->items as $item)

--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -9,7 +9,7 @@
                             :variant="confirmVariant" :callback="confirmCallback"
                             @close="confirmShow=false">
         </confirmation-modal>
-        <b-alert class="d-none d-lg-block" :show="alertShow" id="alertBox" :variant="alertVariant" @dismissed="alertShow = false" dismissible>
+        <b-alert class="d-none d-lg-block" :show="alertShow" id="alertBox" :variant="alertVariant" @dismissed="alertShow=0" dismissible fade>
             @{{alertText}}
         </b-alert>
 

--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -11,7 +11,7 @@
         </confirmation-modal>
 
         <div v-if="alerts.length > 0" class="alert-wrapper">
-            <b-alert v-for="(item, index) in alerts" class="d-none d-lg-block alertBox" :show="item.alertShow" :variant="item.alertVariant" dismissible fade>
+            <b-alert v-for="(item, index) in alerts" :key="index" class="d-none d-lg-block alertBox" :show="item.alertShow" :variant="item.alertVariant" dismissible fade>
                 @{{item.alertText}}
             </b-alert>
         </div>

--- a/tests/Browser/UserEditDeleteTest.php
+++ b/tests/Browser/UserEditDeleteTest.php
@@ -74,7 +74,7 @@ class UserAddEditDeleteTest extends DuskTestCase
                 ->click();  //The delete button lacks a unique ID
             $browser->waitFor('#confirmModal', 10)
                 ->press("#confirm")
-                ->waitFor("#alertBox", 10)
+                ->waitFor(".alertBox", 10)
                 ->assertSee("The user was deleted");
         });
 


### PR DESCRIPTION
Fixes #1581 
- The default timeout is set to 3 seconds, but in reality it shows for like 5 seconds.
- To set the number of seconds it shows for, set a 3rd argument to ProcessMaker.alert
- Set to 0 to show indefinitely until it's closed by the user
- Multiple alerts are stacked
- To test, just click save a bunch of times
![Kapture 2019-03-27 at 13 27 14](https://user-images.githubusercontent.com/2546850/55109904-150bfd80-5094-11e9-8454-8f061cc93a8b.gif)
