### PR TITLE
Browse Away Warning

### DIFF
--- a/resources/views/processes/modeler/index.blade.php
+++ b/resources/views/processes/modeler/index.blade.php
@@ -45,9 +45,19 @@ ol.breadcrumb {
 
 @section('js')
   <script>
-    window.onbeforeunload = function () {
-      return 'Are you sure you want to leave?';
-    }
+    new Vue({
+      created() {
+        window.addEventListener('beforeunload', this.handler)
+      },
+      methods: {
+        handler: function handler(event) {
+          let confirmationMessage = __('Are you sure you want to leave?');
+
+          event.returnValue = confirmationMessage;     // Gecko, Trident, Chrome 34+
+          return confirmationMessage;
+        }
+      }
+    });
   window.ProcessMaker.modeler = {
     process: @json($process),
     xml: @json($process->bpmn)

--- a/resources/views/processes/modeler/index.blade.php
+++ b/resources/views/processes/modeler/index.blade.php
@@ -45,6 +45,9 @@ ol.breadcrumb {
 
 @section('js')
   <script>
+    window.onbeforeunload = function () {
+      return 'Are you sure you want to leave?';
+    }
   window.ProcessMaker.modeler = {
     process: @json($process),
     xml: @json($process->bpmn)

--- a/resources/views/processes/screen-builder/screen.blade.php
+++ b/resources/views/processes/screen-builder/screen.blade.php
@@ -24,9 +24,19 @@
 
 @section('js')
     <script>
-        window.onbeforeunload = function () {
-          return 'Are you sure you want to leave?';
+      new Vue({
+        created() {
+          window.addEventListener('beforeunload', this.handler)
+        },
+        methods: {
+          handler: function handler(event) {
+            let confirmationMessage = __('Are you sure you want to leave?');
+
+            event.returnValue = confirmationMessage;     // Gecko, Trident, Chrome 34+
+            return confirmationMessage;
+          }
         }
+      });
     </script>
     @foreach($manager->getScripts() as $script)
         <script src="{{$script}}"></script>

--- a/resources/views/processes/screen-builder/screen.blade.php
+++ b/resources/views/processes/screen-builder/screen.blade.php
@@ -23,6 +23,11 @@
 @endsection
 
 @section('js')
+    <script>
+        window.onbeforeunload = function () {
+          return 'Are you sure you want to leave?';
+        }
+    </script>
     @foreach($manager->getScripts() as $script)
         <script src="{{$script}}"></script>
     @endforeach


### PR DESCRIPTION
Resolves #1595 

Add alert when the user wants to leave the page.

pages Screen builder and modeler.

note. 
The onbeforeunload event.

The default message that appears in the confirmation box, is different in different browsers. However, the standard message is something like "Are you sure you want to leave this page?". This message cannot be removed.

