### PR TITLE
Use the npm-font-open-sans package correctly

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -9,10 +9,7 @@
 @import '~@fortawesome/fontawesome-free/scss/fontawesome';
 @import '~vue-multiselect/dist/vue-multiselect.min.css';
 
-@font-face {
-  font-family: 'Open Sans';
-  src: url('/fonts/OpenSans.ttf') format('truetype');
-}
+@import '../../node_modules/npm-font-open-sans/open-sans';
 
 // .search-bar {
 //   @extend form-inline;


### PR DESCRIPTION
Fixes #1606 

Import the full open-sans font package, not just the regular variant. Note that this fixes the screen builder however it also changes some visual elements that were previous set to bold, but were not displaying as bold (like the active breadcrumb and table headers)

![image](https://user-images.githubusercontent.com/2546850/55180654-3a0d7880-5147-11e9-9e38-b4abef899dd4.png)
![image](https://user-images.githubusercontent.com/2546850/55180963-e0597e00-5147-11e9-91cf-3d9166e29038.png)
