### PR TITLE
Fix modeler file upload

### DIFF
--- a/resources/js/processes/modeler/components/ModelerApp.vue
+++ b/resources/js/processes/modeler/components/ModelerApp.vue
@@ -64,6 +64,11 @@ export default {
     }
   },
   mounted() {
+    reader.onloadend = () => {
+      this.$refs.modeler.loadXML(reader.result);
+      this.$refs.uploadmodal.hide();
+    };
+
     ProcessMaker.$modeler = this.$refs.modeler;
   },
   methods: {


### PR DESCRIPTION
Fixes #1599.

This PR adds the missing file reader `onloadend` event listener to handle modeler file uploads / imports.